### PR TITLE
Add Simplified Chinese (zh-CN) localization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -829,6 +829,42 @@ Cloud sync requires a Supabase backend. The backend is NOT configured by default
 
 Install the Supabase SDK: `pip install titrack[cloud]`
 
+## Internationalization (i18n)
+
+TITrack supports two languages: **English (en)** (default) and **Simplified Chinese (zh-CN)**. The language is selected from Settings → Language and persisted as the `language` setting. Both the web dashboard and the WPF overlay follow this setting.
+
+### Translation surfaces
+
+| Surface | Source |
+|---------|--------|
+| Web UI static strings | `src/titrack/web/static/i18n.js` `TRANSLATIONS` (~145 keys) |
+| Overlay static strings | `overlay/Localization.cs` `Strings` |
+| Item names | `items.name_en` / `items.name_cn` columns (from `tlidb_items_seed_en.json`) |
+| Zone names | `src/titrack/data/zones.py` `ZONE_NAMES` (en) and `ZONE_NAMES_CN` (zh-CN) |
+| Season / hero names | `src/titrack/parser/player_parser.py` `SEASON_NAMES_*` / `HERO_NAMES_*` |
+
+### Selection rules
+
+- Item name: prefer `name_cn` when language is zh-CN and non-empty; else `name_en`; else legacy `name`; else `Unknown ({id})`.
+- Zone name: looked up by English display name. The runtime `(Nightmare)` suffix is preserved/translated separately so any zone can be displayed in Nightmare mode without duplicating entries.
+- FE (Flame Elementium) is rendered as **源质** in zh-CN copy.
+
+### API endpoints
+
+- `GET /api/i18n/zones` — Returns `{ "zh-CN": { "<EnglishName>": "<译名>", ... } }`. Used by the web app and the overlay to translate zone display names client-side.
+- `GET /api/settings/language` / `PUT /api/settings/language` — Round-trips the user's language choice. `language` is whitelisted in `ALLOWED_SETTINGS`.
+
+### Adding a new translation
+
+1. **UI string**: add the key to both language blocks in `src/titrack/web/static/i18n.js` and `overlay/Localization.cs`. Use it in templates via `data-i18n="key"` (web) or `Localization.Tr("key")` (overlay).
+2. **Zone**: add an entry to `ZONE_NAMES_CN` in `src/titrack/data/zones.py`. The endpoint serves the dict as-is.
+3. **Item**: name_cn comes from the seed JSON. Re-seeding pulls fresh translations.
+4. **Season / hero**: extend the `*_NAMES_CN` dicts in `src/titrack/parser/player_parser.py`.
+
+### Overlay behaviour
+
+The overlay polls `/api/settings/language` every refresh tick (~2 s). When the value changes, `Localization.LanguageChanged` fires and `MainWindow.ApplyLanguageLabels()` re-applies all static labels and tooltips in place — no restart required.
+
 ## Known Limitations / TODO
 
 - **Timemark level not tracked**: The game log zone paths are identical regardless of Timemark level (e.g., 7-0 vs 8-0). Runs of the same zone are grouped together. To support per-Timemark tracking, would need to find another log line that indicates the Timemark level (possibly when selecting beacon or starting map) or add manual run tagging in the UI.

--- a/TITrack.sln
+++ b/TITrack.sln
@@ -1,0 +1,38 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "overlay", "overlay", "{178A59AB-26FA-0D53-5A85-CE27EDD23CDA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "setup", "setup", "{8234297F-5141-16AD-017A-2883AE030302}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TITrackOverlay", "overlay\TITrackOverlay.csproj", "{54454BF6-7EC8-5B4A-1788-F171EE4F837C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TITrackSetup", "setup\TITrackSetup.csproj", "{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{54454BF6-7EC8-5B4A-1788-F171EE4F837C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54454BF6-7EC8-5B4A-1788-F171EE4F837C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54454BF6-7EC8-5B4A-1788-F171EE4F837C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54454BF6-7EC8-5B4A-1788-F171EE4F837C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{54454BF6-7EC8-5B4A-1788-F171EE4F837C} = {178A59AB-26FA-0D53-5A85-CE27EDD23CDA}
+		{8187A547-BAF4-F41E-8E9C-E73E12C3C4BE} = {8234297F-5141-16AD-017A-2883AE030302}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A016221-21FB-4B78-AEAB-275D6DE9F059}
+	EndGlobalSection
+EndGlobal

--- a/overlay/Localization.cs
+++ b/overlay/Localization.cs
@@ -1,0 +1,202 @@
+using System.Net.Http;
+using System.Text.Json;
+
+namespace TITrackOverlay;
+
+/// <summary>
+/// Lightweight localization helper for the overlay window.
+///
+/// Mirrors the web frontend's i18n.js behaviour:
+/// - Two languages: "en" (default) and "zh-CN".
+/// - Item-name selection prefers name_cn when language == zh-CN and name_cn is non-empty,
+///   otherwise falls back to name_en (or the legacy name field).
+/// - Zone names are translated via a table downloaded once from /api/i18n/zones.
+/// - Static UI strings (labels, "No active run", supply alerts, tooltips) are looked
+///   up in <see cref="Strings"/>; missing keys fall back to English.
+///
+/// The overlay polls the language setting every refresh tick. When the value
+/// changes, <see cref="LanguageChanged"/> fires so the UI can reapply labels.
+/// </summary>
+internal static class Localization
+{
+    public const string LangEn = "en";
+    public const string LangZh = "zh-CN";
+
+    public static string CurrentLang { get; private set; } = LangEn;
+
+    /// <summary>Fired when SetLang() actually changes the current language.</summary>
+    public static event Action<string>? LanguageChanged;
+
+    private static Dictionary<string, string>? _zoneNamesCn;
+    private static bool _zonesLoadAttempted;
+
+    // Static UI strings. Keep keys identical to the Python/JS side where possible.
+    private static readonly Dictionary<string, Dictionary<string, string>> Strings = new()
+    {
+        [LangEn] = new()
+        {
+            // Main overlay labels
+            ["overlay.title"] = "TITrack Overlay",
+            ["overlay.net_worth"] = "Net Worth",
+            ["overlay.this_run"] = "This Run",
+            ["overlay.previous_run"] = "Previous Run",
+            ["overlay.fe_per_hour"] = "FE/Hour",
+            ["overlay.fe_per_map"] = "FE/Map",
+            ["overlay.runs"] = "Runs",
+            ["overlay.avg_time"] = "Avg Time",
+            ["overlay.total_time"] = "Total Time",
+            ["overlay.no_active_run"] = "No active run",
+            ["overlay.unknown_zone"] = "Unknown Zone",
+            // Tooltips
+            ["overlay.tip_decrease_text"] = "Decrease text size",
+            ["overlay.tip_increase_text"] = "Increase text size",
+            ["overlay.tip_transparency"] = "Toggle transparency",
+            ["overlay.tip_pause"] = "Pause/resume tracking",
+            ["overlay.tip_lock"] = "Lock overlay (click-through)",
+            ["overlay.tip_close"] = "Close overlay",
+            // Supply alert (mirrors low-supply toast text on the web)
+            ["overlay.supply_alert"] = "\u26a0 Low: {0} \u2014 {1} left",
+            // Micro overlay short labels
+            ["micro.time"] = "Time",
+            ["micro.fe_per_hr"] = "FE/hr",
+            ["micro.total"] = "Total",
+            ["micro.nw"] = "NW",
+            ["micro.run"] = "Run",
+            ["micro.fe_per_map"] = "FE/Map",
+            ["micro.runs"] = "Runs",
+            ["micro.avg"] = "Avg",
+            // Misc
+            ["overlay.unknown_item"] = "Unknown ({0})",
+        },
+        [LangZh] = new()
+        {
+            ["overlay.title"] = "TITrack \u60ac\u6d6e\u7a97",
+            ["overlay.net_worth"] = "\u51c0\u8d44\u4ea7",
+            ["overlay.this_run"] = "\u5f53\u524d\u5730\u56fe",
+            ["overlay.previous_run"] = "\u4e0a\u4e00\u5f20\u5730\u56fe",
+            ["overlay.fe_per_hour"] = "\u6e90\u8d28/\u5c0f\u65f6",
+            ["overlay.fe_per_map"] = "\u6e90\u8d28/\u56fe",
+            ["overlay.runs"] = "\u5730\u56fe\u6570",
+            ["overlay.avg_time"] = "\u5e73\u5747\u65f6\u95f4",
+            ["overlay.total_time"] = "\u603b\u65f6\u957f",
+            ["overlay.no_active_run"] = "\u5f53\u524d\u672a\u5728\u5730\u56fe\u4e2d",
+            ["overlay.unknown_zone"] = "\u672a\u77e5\u533a\u57df",
+            ["overlay.tip_decrease_text"] = "\u7f29\u5c0f\u6587\u5b57",
+            ["overlay.tip_increase_text"] = "\u653e\u5927\u6587\u5b57",
+            ["overlay.tip_transparency"] = "\u5207\u6362\u900f\u660e\u5ea6",
+            ["overlay.tip_pause"] = "\u6682\u505c / \u7ee7\u7eed\u8ba1\u65f6",
+            ["overlay.tip_lock"] = "\u9501\u5b9a\u60ac\u6d6e\u7a97\uff08\u70b9\u51fb\u7a7f\u900f\uff09",
+            ["overlay.tip_close"] = "\u5173\u95ed\u60ac\u6d6e\u7a97",
+            ["overlay.supply_alert"] = "\u26a0 \u4f4e\u5e93\u5b58\uff1a{0} \u2014 \u5269\u4f59 {1}",
+            ["micro.time"] = "\u65f6\u957f",
+            ["micro.fe_per_hr"] = "\u6e90\u8d28/\u65f6",
+            ["micro.total"] = "\u603b\u989d",
+            ["micro.nw"] = "\u51c0\u8d44",
+            ["micro.run"] = "\u672c\u56fe",
+            ["micro.fe_per_map"] = "\u6e90\u8d28/\u56fe",
+            ["micro.runs"] = "\u5730\u56fe\u6570",
+            ["micro.avg"] = "\u5747\u503c",
+            ["overlay.unknown_item"] = "\u672a\u77e5\u7269\u54c1\uff08{0}\uff09",
+        },
+    };
+
+    /// <summary>Translate a key. Falls back to English then the key itself.</summary>
+    public static string Tr(string key)
+    {
+        if (Strings.TryGetValue(CurrentLang, out var dict) && dict.TryGetValue(key, out var s))
+            return s;
+        if (Strings[LangEn].TryGetValue(key, out var fallback))
+            return fallback;
+        return key;
+    }
+
+    /// <summary>Translate with positional substitution (string.Format-style).</summary>
+    public static string Tr(string key, params object?[] args)
+    {
+        return string.Format(Tr(key), args);
+    }
+
+    /// <summary>
+    /// Pick the best display name for a JSON-loot item, considering name_cn / name_en
+    /// / legacy name in priority order.
+    /// </summary>
+    public static string PickItemName(string? nameEn, string? nameCn, string? legacyName, int configBaseId)
+    {
+        if (CurrentLang == LangZh && !string.IsNullOrEmpty(nameCn))
+            return nameCn!;
+        if (!string.IsNullOrEmpty(nameEn))
+            return nameEn!;
+        if (!string.IsNullOrEmpty(legacyName))
+            return legacyName!;
+        return Tr("overlay.unknown_item", configBaseId);
+    }
+
+    /// <summary>
+    /// Translate a zone display name. Returns the original English string when
+    /// no translation table is loaded or no entry matches; preserves the
+    /// " (Nightmare)" runtime suffix.
+    /// </summary>
+    public static string TZone(string? englishName)
+    {
+        if (string.IsNullOrEmpty(englishName) || CurrentLang == LangEn) return englishName ?? string.Empty;
+        if (_zoneNamesCn == null) return englishName!;
+
+        if (_zoneNamesCn.TryGetValue(englishName!, out var hit))
+            return hit;
+
+        const string nm = " (Nightmare)";
+        if (englishName!.EndsWith(nm, StringComparison.Ordinal))
+        {
+            var baseName = englishName[..^nm.Length];
+            var baseTr = _zoneNamesCn.TryGetValue(baseName, out var b) ? b : baseName;
+            var nmSuffix = _zoneNamesCn.TryGetValue("(Nightmare)", out var n) ? n : nm;
+            return baseTr + nmSuffix;
+        }
+        return englishName;
+    }
+
+    /// <summary>Set the active language and notify subscribers if it changed.</summary>
+    public static void SetLang(string? lang)
+    {
+        var normalized = lang == LangZh ? LangZh : LangEn;
+        if (normalized == CurrentLang) return;
+        CurrentLang = normalized;
+        LanguageChanged?.Invoke(CurrentLang);
+    }
+
+    /// <summary>
+    /// Fetch the zone-translation table from /api/i18n/zones. Idempotent: only
+    /// runs once per process; subsequent calls are no-ops.
+    /// </summary>
+    public static async Task EnsureZoneTranslationsAsync(HttpClient http, string baseUrl)
+    {
+        if (_zonesLoadAttempted) return;
+        _zonesLoadAttempted = true;
+        try
+        {
+            var resp = await http.GetAsync($"{baseUrl}/api/i18n/zones");
+            if (!resp.IsSuccessStatusCode) return;
+            var json = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty(LangZh, out var zhEl))
+            {
+                var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+                foreach (var prop in zhEl.EnumerateObject())
+                {
+                    if (prop.Value.ValueKind == JsonValueKind.String)
+                    {
+                        var v = prop.Value.GetString();
+                        if (!string.IsNullOrEmpty(v))
+                            dict[prop.Name] = v!;
+                    }
+                }
+                _zoneNamesCn = dict;
+            }
+        }
+        catch
+        {
+            // Offline-friendly: fall back to English on any error.
+            _zonesLoadAttempted = false; // allow retry next refresh
+        }
+    }
+}

--- a/overlay/MainWindow.xaml.cs
+++ b/overlay/MainWindow.xaml.cs
@@ -60,21 +60,34 @@ public partial class MainWindow : Window
     private double _savedNormalLeft = double.NaN;
     private double _savedNormalTop = double.NaN;
 
-    // Micro stat display config
-    private static readonly Dictionary<string, string> MicroStatLabels = new()
+    // Micro stat short labels: keyed by stat id, value is the i18n key. The actual
+    // displayed string is resolved through Localization at render time so the
+    // labels switch immediately when the user changes language.
+    private static readonly Dictionary<string, string> MicroStatLabelKeys = new()
     {
-        { "total_time", "Time" },
-        { "value_per_hour", "FE/hr" },
-        { "total_value", "Total" },
-        { "net_worth", "NW" },
-        { "this_run", "Run" },
-        { "value_per_map", "FE/Map" },
-        { "runs", "Runs" },
-        { "avg_time", "Avg" },
+        { "total_time", "micro.time" },
+        { "value_per_hour", "micro.fe_per_hr" },
+        { "total_value", "micro.total" },
+        { "net_worth", "micro.nw" },
+        { "this_run", "micro.run" },
+        { "value_per_map", "micro.fe_per_map" },
+        { "runs", "micro.runs" },
+        { "avg_time", "micro.avg" },
     };
 
+    private static bool TryGetMicroLabel(string statKey, out string label)
+    {
+        if (MicroStatLabelKeys.TryGetValue(statKey, out var i18nKey))
+        {
+            label = Localization.Tr(i18nKey);
+            return true;
+        }
+        label = string.Empty;
+        return false;
+    }
+
     // Supply alert state
-    private record SupplyItemRecord(int config_base_id, string name, string category, int quantity);
+    private record SupplyItemRecord(int config_base_id, string name, string category, int quantity, string? name_en = null, string? name_cn = null);
     private record SupplyItemsResponse(SupplyItemRecord[] items);
     private readonly HashSet<string> _supplyAlertedItems = new();
     private int _supplyBeaconThreshold = 0;
@@ -131,7 +144,9 @@ public partial class MainWindow : Window
         int quantity,
         string? icon_url,
         double? price_fe,
-        double? total_value_fe
+        double? total_value_fe,
+        string? name_en = null,
+        string? name_cn = null
     );
 
     private record ActiveRunResponse(
@@ -186,6 +201,12 @@ public partial class MainWindow : Window
 
         Loaded += async (s, e) =>
         {
+            // Apply language first so initial labels render in the right language.
+            await LoadLanguageAsync();
+            await Localization.EnsureZoneTranslationsAsync(_httpClient, App.BaseUrl);
+            ApplyLanguageLabels();
+            Localization.LanguageChanged += _ => ApplyLanguageLabels();
+
             await LoadTransparencyAsync();
             await LoadFontScaleAsync();
             await LoadHideLootAsync();
@@ -473,6 +494,67 @@ public partial class MainWindow : Window
         FontIncreaseButton.IsEnabled = _fontScale < MaxFontScale;
         FontDecreaseButton.Opacity = _fontScale > MinFontScale ? 1.0 : 0.4;
         FontIncreaseButton.Opacity = _fontScale < MaxFontScale ? 1.0 : 0.4;
+    }
+
+    /// <summary>
+    /// Read the saved language setting from the backend and apply it via
+    /// <see cref="Localization.SetLang"/>. Triggers <c>LanguageChanged</c> only
+    /// when the value actually changes, so this is cheap to call every refresh.
+    /// </summary>
+    private async Task LoadLanguageAsync()
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{App.BaseUrl}/api/settings/language");
+            if (!response.IsSuccessStatusCode) return;
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("value", out var v) && v.ValueKind == JsonValueKind.String)
+            {
+                Localization.SetLang(v.GetString());
+                // Make sure the zone table is loaded once we know we may need it.
+                await Localization.EnsureZoneTranslationsAsync(_httpClient, App.BaseUrl);
+            }
+        }
+        catch
+        {
+            // Offline-friendly: keep the previous language.
+        }
+    }
+
+    /// <summary>
+    /// Apply the current language to all static labels, tooltips, and the
+    /// micro-overlay panel. Called once on load and again whenever
+    /// <see cref="Localization.LanguageChanged"/> fires.
+    /// </summary>
+    private void ApplyLanguageLabels()
+    {
+        Title = Localization.Tr("overlay.title");
+        NetWorthLabel.Text = Localization.Tr("overlay.net_worth");
+        // ThisRunLabel is updated dynamically (active vs previous) in UpdateStats;
+        // initialize it here so the first paint shows the right text.
+        ThisRunLabel.Text = Localization.Tr("overlay.this_run");
+        ValuePerHourLabel.Text = Localization.Tr("overlay.fe_per_hour");
+        ValuePerMapLabel.Text = Localization.Tr("overlay.fe_per_map");
+        RunsLabel.Text = Localization.Tr("overlay.runs");
+        AvgTimeLabel.Text = Localization.Tr("overlay.avg_time");
+        TotalTimeLabel.Text = Localization.Tr("overlay.total_time");
+        NoRunText.Text = Localization.Tr("overlay.no_active_run");
+
+        // Tooltips
+        FontDecreaseButton.ToolTip = Localization.Tr("overlay.tip_decrease_text");
+        FontIncreaseButton.ToolTip = Localization.Tr("overlay.tip_increase_text");
+        TransparencyButton.ToolTip = Localization.Tr("overlay.tip_transparency");
+        PauseButton.ToolTip = Localization.Tr("overlay.tip_pause");
+        LockButton.ToolTip = Localization.Tr("overlay.tip_lock");
+        MicroTransparencyButton.ToolTip = Localization.Tr("overlay.tip_transparency");
+        MicroLockButton.ToolTip = Localization.Tr("overlay.tip_lock");
+
+        // Refresh micro panel labels (loop updates label TextBlocks via a rebuild).
+        if (_microMode)
+        {
+            RebuildMicroStats();
+        }
     }
 
     private async Task LoadFontScaleAsync()
@@ -887,7 +969,7 @@ public partial class MainWindow : Window
         for (int i = 0; i < _microStats.Count; i++)
         {
             var key = _microStats[i];
-            if (!MicroStatLabels.TryGetValue(key, out var label))
+            if (!TryGetMicroLabel(key, out var label))
                 continue;
 
             if (isVertical)
@@ -1262,6 +1344,10 @@ public partial class MainWindow : Window
     {
         try
         {
+            // Poll language setting so the overlay follows changes made in the
+            // dashboard's Settings modal without restarting.
+            await LoadLanguageAsync();
+
             var statsTask = FetchAsync<StatsResponse>("/api/runs/stats");
             var activeRunTask = FetchAsync<ActiveRunResponse?>("/api/runs/active");
             var inventoryTask = FetchAsync<InventoryResponse>("/api/inventory");
@@ -1349,7 +1435,7 @@ public partial class MainWindow : Window
 
             if (item.quantity <= threshold && !_supplyAlertedItems.Contains(alertKey))
             {
-                alerts.Add($"\u26a0 Low: {item.name} \u2014 {item.quantity} left");
+                alerts.Add(Localization.Tr("overlay.supply_alert", Localization.PickItemName(item.name_en, item.name_cn, item.name, item.config_base_id), item.quantity));
                 _supplyAlertedItems.Add(alertKey);
             }
             else if (item.quantity > threshold && _supplyAlertedItems.Contains(alertKey))
@@ -1436,12 +1522,12 @@ public partial class MainWindow : Window
                 : (Brush)FindResource("AccentRedBrush");
 
             // Update label based on whether it's active or previous
-            ThisRunLabel.Text = activeRun != null ? "This Run" : "Previous Run";
+            ThisRunLabel.Text = activeRun != null ? Localization.Tr("overlay.this_run") : Localization.Tr("overlay.previous_run");
         }
         else
         {
             ThisRunText.Text = "--";
-            ThisRunLabel.Text = "This Run";
+            ThisRunLabel.Text = Localization.Tr("overlay.this_run");
         }
 
         // Other stats
@@ -1526,7 +1612,7 @@ public partial class MainWindow : Window
         NoRunPanel.Visibility = Visibility.Collapsed;
 
         // Zone name and duration
-        ZoneNameText.Text = displayRun.zone_name ?? "Unknown Zone";
+        ZoneNameText.Text = Localization.TZone(displayRun.zone_name) ?? Localization.Tr("overlay.unknown_zone");
         RunDurationText.Text = $"({FormatDurationShort(displayRun.duration_seconds)})";
 
         // Show/hide pulse indicator based on active vs previous run
@@ -1629,7 +1715,7 @@ public partial class MainWindow : Window
         // Name
         var nameText = new TextBlock
         {
-            Text = item.name ?? $"Unknown ({item.config_base_id})",
+            Text = Localization.PickItemName(item.name_en, item.name_cn, item.name, item.config_base_id),
             Foreground = nameBrush,
             FontSize = 11,
             TextTrimming = TextTrimming.CharacterEllipsis,

--- a/src/titrack/api/app.py
+++ b/src/titrack/api/app.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from titrack.api.routes import cloud, collector as collector_routes, icons, inventory, items, prices, runs, settings, stats, update
+from titrack.api.routes import cloud, collector as collector_routes, i18n, icons, inventory, items, prices, runs, settings, stats, update
 from titrack.api.schemas import PlayerResponse, StatusResponse
 from titrack.config.paths import get_static_dir
 from titrack.db.connection import Database
@@ -85,6 +85,7 @@ def create_app(
     app.include_router(cloud.router)
     app.include_router(update.router)
     app.include_router(collector_routes.router)
+    app.include_router(i18n.router)
 
     # Initialize update manager
     try:
@@ -156,8 +157,12 @@ def create_app(
             level=pi.level,
             season_id=pi.season_id,
             season_name=pi.season_name,
+            season_name_en=pi.season_name,
+            season_name_cn=pi.season_name_cn,
             hero_id=pi.hero_id,
             hero_name=pi.hero_name,
+            hero_name_en=pi.hero_name,
+            hero_name_cn=pi.hero_name_cn,
             player_id=pi.player_id,
         )
 

--- a/src/titrack/api/routes/i18n.py
+++ b/src/titrack/api/routes/i18n.py
@@ -1,0 +1,19 @@
+"""Internationalization API routes (zone translations etc.)."""
+
+from fastapi import APIRouter
+
+from titrack.data.zones import ZONE_NAMES_CN
+
+router = APIRouter(prefix="/api/i18n", tags=["i18n"])
+
+
+@router.get("/zones")
+def get_zone_translations() -> dict[str, dict[str, str]]:
+    """Return zone-name translation tables keyed by English display name.
+
+    Shape: ``{"zh-CN": {"Hideout - Ember's Rest": "驻地 - 余烬避难所", ...}}``
+    The web client looks up zone names using the English label it already
+    receives from ``/api/runs`` and falls back to the English label if no
+    translation exists.
+    """
+    return {"zh-CN": ZONE_NAMES_CN}

--- a/src/titrack/api/routes/inventory.py
+++ b/src/titrack/api/routes/inventory.py
@@ -61,7 +61,19 @@ def get_consumed_supplies(
     repo: Repository = Depends(get_repository),
 ) -> SupplyItemsResponse:
     """Get consumed supply items with current quantities for alerts."""
-    items = repo.get_consumed_supply_items()
+    raw = repo.get_consumed_supply_items()
+    items = []
+    for entry in raw:
+        cid = entry["config_base_id"]
+        item = repo.get_item(cid)
+        items.append({
+            "config_base_id": cid,
+            "name": entry["name"],
+            "name_en": item.name_en if item else None,
+            "name_cn": item.name_cn if item else None,
+            "category": entry["category"],
+            "quantity": entry["quantity"],
+        })
     return SupplyItemsResponse(items=items)
 
 
@@ -133,6 +145,10 @@ def get_inventory(
             InventoryItem(
                 config_base_id=config_id,
                 name=item.name_en if item else f"Unknown {config_id}",
+                name_en=item.name_en if item else None,
+                name_cn=item.name_cn if item else None,
+                url_en=item.url_en if item else None,
+                url_cn=item.url_cn if item else None,
                 quantity=quantity,
                 page_id=page_ids.get(config_id, 0),
                 icon_url=item.icon_url if item else None,

--- a/src/titrack/api/routes/runs.py
+++ b/src/titrack/api/routes/runs.py
@@ -72,6 +72,10 @@ def _build_loot(summary: dict[int, int], repo: Repository) -> list[LootItem]:
                 LootItem(
                     config_base_id=config_id,
                     name=item.name_en if item else f"Unknown {config_id}",
+                    name_en=item.name_en if item else None,
+                    name_cn=item.name_cn if item else None,
+                    url_en=item.url_en if item else None,
+                    url_cn=item.url_cn if item else None,
                     quantity=quantity,
                     icon_url=item.icon_url if item else None,
                     price_fe=item_price_fe,
@@ -97,6 +101,10 @@ def _build_cost_items(cost_summary: dict[int, int], repo: Repository) -> list[Lo
                 LootItem(
                     config_base_id=config_id,
                     name=item.name_en if item else f"Unknown {config_id}",
+                    name_en=item.name_en if item else None,
+                    name_cn=item.name_cn if item else None,
+                    url_en=item.url_en if item else None,
+                    url_cn=item.url_cn if item else None,
                     quantity=quantity,  # Keep negative to indicate consumption
                     icon_url=item.icon_url if item else None,
                     price_fe=item_price_fe,
@@ -766,6 +774,10 @@ def get_loot_report(
             LootReportItem(
                 config_base_id=config_id,
                 name=item.name_en if item else f"Unknown {config_id}",
+                name_en=item.name_en if item else None,
+                name_cn=item.name_cn if item else None,
+                url_en=item.url_en if item else None,
+                url_cn=item.url_cn if item else None,
                 quantity=quantity,
                 icon_url=item.icon_url if item else None,
                 price_fe=price_fe,

--- a/src/titrack/api/routes/settings.py
+++ b/src/titrack/api/routes/settings.py
@@ -40,6 +40,7 @@ ALLOWED_SETTINGS = {
     "low_supply_beacon_threshold",
     "low_supply_compass_threshold",
     "low_supply_resonance_threshold",
+    "language",
 }
 
 # Settings that are read-only via API (can be read but not written)

--- a/src/titrack/api/schemas.py
+++ b/src/titrack/api/schemas.py
@@ -10,7 +10,11 @@ class LootItem(BaseModel):
     """Single item in loot breakdown."""
 
     config_base_id: int
-    name: str
+    name: str  # Backwards-compat: equals name_en
+    name_en: Optional[str] = None
+    name_cn: Optional[str] = None
+    url_en: Optional[str] = None
+    url_cn: Optional[str] = None
     quantity: int
     icon_url: Optional[str] = None
     price_fe: Optional[float] = None  # Price per unit
@@ -89,7 +93,11 @@ class InventoryItem(BaseModel):
     """Single item in inventory."""
 
     config_base_id: int
-    name: str
+    name: str  # Backwards-compat: equals name_en
+    name_en: Optional[str] = None
+    name_cn: Optional[str] = None
+    url_en: Optional[str] = None
+    url_cn: Optional[str] = None
     quantity: int
     page_id: int = 0
     icon_url: Optional[str] = None
@@ -185,9 +193,13 @@ class PlayerResponse(BaseModel):
     name: str
     level: int
     season_id: int
-    season_name: str
+    season_name: str  # Backwards-compat: equals season_name_en
+    season_name_en: Optional[str] = None
+    season_name_cn: Optional[str] = None
     hero_id: int
-    hero_name: str
+    hero_name: str  # Backwards-compat: equals hero_name_en
+    hero_name_en: Optional[str] = None
+    hero_name_cn: Optional[str] = None
     player_id: Optional[str] = None
 
 
@@ -195,7 +207,11 @@ class LootReportItem(BaseModel):
     """Single item in loot report."""
 
     config_base_id: int
-    name: str
+    name: str  # Backwards-compat: equals name_en
+    name_en: Optional[str] = None
+    name_cn: Optional[str] = None
+    url_en: Optional[str] = None
+    url_cn: Optional[str] = None
     quantity: int
     icon_url: Optional[str] = None
     price_fe: Optional[float] = None  # Price per unit
@@ -242,7 +258,9 @@ class SupplyItem(BaseModel):
     """A single supply item with its current quantity."""
 
     config_base_id: int
-    name: str
+    name: str  # Backwards-compat: equals name_en
+    name_en: Optional[str] = None
+    name_cn: Optional[str] = None
     category: str
     quantity: int
 

--- a/src/titrack/cli/commands.py
+++ b/src/titrack/cli/commands.py
@@ -596,6 +596,15 @@ def _serve_browser_mode(args: argparse.Namespace, settings: Settings, logger, sh
         api_db = Database(settings.db_path)
         api_db.connect()
 
+        # Ensure cloud sync is available even when no log file has been seen
+        # yet (collector hasn't started). This lets the dashboard's Cloud Sync
+        # toggle work on a fresh install before the game has been launched.
+        if sync_manager is None:
+            sync_manager = SyncManager(api_db)
+            sync_manager.initialize()
+            if player_info:
+                sync_manager.set_season_context(player_info.season_id)
+
         # Create FastAPI app
         app = create_app(
             db=api_db,
@@ -1042,6 +1051,15 @@ def _serve_with_window(args: argparse.Namespace, settings: Settings, logger, sho
         # API gets its own database connection
         api_db = Database(settings.db_path)
         api_db.connect()
+
+        # Ensure cloud sync is available even when no log file has been seen
+        # yet (collector hasn't started). This lets the dashboard's Cloud Sync
+        # toggle work on a fresh install before the game has been launched.
+        if sync_manager is None:
+            sync_manager = SyncManager(api_db)
+            sync_manager.initialize()
+            if player_info:
+                sync_manager.set_season_context(player_info.season_id)
 
         # Create FastAPI app (window mode, not browser fallback)
         app = create_app(

--- a/src/titrack/data/zones.py
+++ b/src/titrack/data/zones.py
@@ -221,3 +221,146 @@ def get_zone_display_name(zone_path: str, level_id: int | None = None) -> str:
             return cleaned if cleaned else part
 
     return zone_path
+
+
+# Chinese translations of zone display names (the English values from
+# ZONE_NAMES / AMBIGUOUS_ZONES / LEVEL_ID_ZONES). Keyed by the *English*
+# display string so the web client can translate without re-implementing
+# zone-path resolution. Missing keys fall back to the English string.
+ZONE_NAMES_CN: dict[str, str] = {
+    # Hideouts
+    "Hideout - Ember's Rest": "驻地 - 余烬避难所",
+    "Hideout - Sacred Court Manor": "驻地 - 圣庭庄园",
+
+    # Sandlord
+    "Cloud Oasis (Sandlord)": "云端绿洲（沙王）",
+    "Quicksand Treasure Stash (Sandlord)": "流沙中的琳琅宝库（沙王）",
+
+    # Blistering Lava Sea
+    "Blistering Lava Sea - Elemental Mine": "沸涌炎海 - 元素矿洞",
+    "Blistering Lava Sea - Path of Sacrifice": "沸涌炎海 - 献身之路",
+    "Blistering Lava Sea - Dragonrest Cavern": "沸涌炎海 - 龙眠峡谷",
+    "Blistering Lava Sea - Where Lies Confession": "沸涌炎海 - 告罪之间",
+    "Blistering Lava Sea - Sunset Dome Bottom": "沸涌炎海 - 落日穹底",
+    "Blistering Lava Sea - Savage Grasslands": "沸涌炎海 - 蛮荒原野",
+    "Blistering Lava Sea - Shimmering Hall": "沸涌炎海 - 微光礼堂",
+    "Blistering Lava Sea - Heart of the Mountains": "沸涌炎海 - 群山之心",
+    "Blistering Lava Sea - Confession Chapel": "沸涌炎海 - 忽罪学院",
+    "Blistering Lava Sea - Twisted Valley": "沸涌炎海 - 曲折谷地",
+    "Blistering Lava Sea - Court of Darkness": "沸涌炎海 - 暗夜王庭",
+    "Blistering Lava Sea - Smelting Plant": "沸涌炎海 - 熔铁工厂",
+    "Blistering Lava Sea - Hellfire Chasm": "沸涌炎海 - 焰狱之谷",
+
+    # Glacial Abyss
+    "Glacial Abyss - High Court Maze": "冰封寒渊 - 圣庭迷宫",
+    "Glacial Abyss - Defiled Side Chamber": "冰封寒渊 - 渎神偏殿",
+    "Glacial Abyss - Deserted District": "冰封寒渊 - 杂芜街区",
+    "Glacial Abyss - Singing Sand": "冰封寒渊 - 鸣沙村落",
+    "Glacial Abyss - Shadow Outpost": "冰封寒渊 - 暗影前哨",
+    "Demiman Village": "亚人村落",
+    "Glacial Abyss - Demiman Village": "冰封寒渊 - 亚人村落",
+    "Glacial Abyss - Abandoned Mines": "冰封寒渊 - 荒弃矿场",
+    "Glacial Abyss - Rainforest of Divine Legacy": "冰封寒渊 - 神遗雨林",
+    "Glacial Abyss - Swirling Mines": "冰封寒渊 - 回旋矿场",
+    "Grimwind Woods": "悲风林地",
+    "Glacial Abyss - Grimwind Woods": "冰封寒渊 - 悲风林地",
+    "Glacial Abyss - Wall of the Last Breath": "冰封寒渊 - 终息高墙",
+    "Glacial Abyss - Blustery Canyon": "冰封寒渊 - 风鸣峡谷",
+    "Glacial Abyss - Throne of Winter": "冰封寒渊 - 永霜冰魄",
+
+    # Boss zones
+    "Rusted Abyss": "锈蚀深渊",
+
+    # Ruins of Aeterna
+    "Ruins of Aeterna: Boundless": "永恒废墟：无尽",
+    "The Frozen Canvas": "雪域熔炉",
+
+    # Vorax
+    "Vorax - Shelly's Operating Theater": "灭世之喙 - 谢莉的手术室",
+
+    # Steel Forge
+    "Steel Forge - Shrine of Despair": "钢铁炼境 - 绝望秘殿",
+    "Steel Forge - Shrine of Punishment": "钢铁炼境 - 苦罚秘殿",
+    "Steel Forge - Beast Plains": "钢铁炼境 - 聚兽平原",
+    "Steel Forge - Thorny Filth": "钢铁炼境 - 荆棘秽土",
+    "Steel Forge - Weeping Mines": "钢铁炼境 - 悲鸣矿区",
+    "Steel Forge - Cloud Walls": "钢铁炼境 - 云间高墙",
+    "Steel Forge - Alleys of the Lost": "钢铁炼境 - 遗落街巷",
+    "Steel Forge - City of Eternal Fire": "钢铁炼境 - 长明宫城",
+    "Steel Forge - Wall of the Pure": "钢铁炼境 - 无垢之墙",
+    "Steel Forge - Sun Temple": "钢铁炼境 - 日栖神庙",
+    "Steel Forge - Corona Shrine": "钢铁炼境 - 日冕神殿",
+    "Steel Forge - Windbreath Cliff": "钢铁炼境 - 风息峦壁",
+    "Steel Forge - Imaginary Monument": "钢铁炼境 - 赤魂武士",
+
+    # Thunder Wastes
+    "Thunder Wastes - Wall of Sorrows": "雷鸣废土 - 悲歌之墙",
+    "Thunder Wastes - Alleys of Pilgrims": "雷鸣废土 - 朝圣街巷",
+    "Thunder Wastes - Desolate Village": "雷鸣废土 - 恶武荒村",
+    "Thunder Wastes - Hall in the Mirror": "雷鸣废土 - 镜中礼堂",
+    "Thunder Wastes - Defiled Oasis": "雷鸣废土 - 不洁绿洲",
+    "Thunder Wastes - King's Hub": "雷鸣废土 - 王者枢纽",
+    "Thunder Wastes - Thirsty Mines": "雷鸣废土 - 干涃矿场",
+    "Thunder Wastes - Rainmist Jungle": "雷鸣废土 - 雾雨密林",
+    "Thunder Wastes - Prayer Sanctuary": "雷鸣废土 - 祷告圣堂",
+    "Thunder Wastes - Sacred Courtyard": "雷鸣废土 - 圣教庭院",
+    "Thunder Wastes - Gallery of Moon": "雷鸣废土 - 新月长廊",
+    "Thunder Wastes - Summit of Thunder": "雷鸣废土 - 灾厄之林",
+
+    # Rift of Dimensions
+    "Rift of Dimensions": "裂隙空境",
+
+    # Secret Realms
+    "Secret Realm - Invaluable Time": "秘境 - 莹光殿堂",
+    "Secret Realm - Sea of Rites": "秘境 - 噩梦之匣",
+    "Secret Realm - Unholy Pedestal": "秘境 - 污秽王座",
+    "Secret Realm - Abyssal Vault": "秘境 - 降神巢",
+
+    # Misc
+    "Supreme Showdown": "巅峰对决",
+    "Fateful Contest": "宿命对局",
+    "Mistville": "雾都遗址",
+    "Void Sea Terminal": "虚空终港",
+
+    # Deep Space
+    "Deep Space - Boundless Hunting Ground": "深空 - 广袤猎场",
+    "Deep Space - Core Mine": "深空 - 地心矿场",
+    "Deep Space - Desert Pasture": "深空 - 沙中牧原",
+    "Deep Space - Barren Wilderness": "深空 - 大荒之野",
+    "Deep Space - Vast Wasteland": "深空 - 万顷荒林",
+
+    # Voidlands
+    "Voidlands - Mundane Palace": "幽夜暗域 - 常世宫闱",
+    "Voidlands - Grimwind Woods": "幽夜暗域 - 悲风林地",
+    "Voidlands - Elemental Mine": "幽夜暗域 - 元素矿洞",
+    "Voidlands - Grim Alleys": "幽夜暗域 - 幽暗街巷",
+    "Voidlands - Filthy Forest": "幽夜暗域 - 污浊丛林",
+    "Voidlands - Dreamless Thicket": "幽夜暗域 - 迷雾雨林",
+    "Voidlands - Luminescent Throne": "幽夜暗域 - 流光神座",
+    "Voidlands - Shrine of Agony": "幽夜暗域 - 苦痛秘殿",
+    "Voidlands - Shimmering Swamp": "幽夜暗域 - 微光沼泽",
+    "Voidlands - Jungle of the Brood": "幽夜暗域 - 母巢密林",
+    "Voidlands - Gallery of Stars": "幽夜暗域 - 群星长廊",
+    "Voidlands - Yesterday Chamber": "幽夜暗域 - 昔日之所",
+    "Voidlands - Dreamless Abyss": "幽夜暗域 - 凋零妄域",
+
+    # Trial of Divinity / Path of the Brave
+    "Trial of Divinity": "神威试炼",
+    "Path of the Brave": "勇者之路",
+
+    # Suffixes used at runtime
+    "(Nightmare)": "（梦魇）",
+}
+
+
+def get_zone_display_name_cn(english_name: str) -> str:
+    """
+    Return the Chinese translation of an English zone display name.
+
+    Falls back to the English string if no translation exists. Also handles
+    the runtime-appended " (Nightmare)" suffix.
+    """
+    if english_name.endswith(" (Nightmare)"):
+        base = english_name[: -len(" (Nightmare)")]
+        return f"{ZONE_NAMES_CN.get(base, base)}（梦魇）"
+    return ZONE_NAMES_CN.get(english_name, english_name)

--- a/src/titrack/parser/player_parser.py
+++ b/src/titrack/parser/player_parser.py
@@ -18,13 +18,23 @@ class PlayerInfo:
 
     @property
     def season_name(self) -> str:
-        """Get human-readable season/league name."""
+        """Get human-readable season/league name (English)."""
         return SEASON_NAMES.get(self.season_id, f"Season {self.season_id}")
 
     @property
+    def season_name_cn(self) -> str:
+        """Get human-readable season/league name (Chinese)."""
+        return SEASON_NAMES_CN.get(self.season_id, self.season_name)
+
+    @property
     def hero_name(self) -> str:
-        """Get human-readable hero/class name."""
+        """Get human-readable hero/class name (English)."""
         return HERO_NAMES.get(self.hero_id, f"Hero {self.hero_id}")
+
+    @property
+    def hero_name_cn(self) -> str:
+        """Get human-readable hero/class name (Chinese)."""
+        return HERO_NAMES_CN.get(self.hero_id, self.hero_name)
 
 
 # Patterns for parsing player data from enter log
@@ -73,6 +83,31 @@ HERO_NAMES = {
     2000: "Oracle",
     2100: "Leonel",
     2200: "Cateye",
+}
+
+
+# Season ID to Chinese name mapping
+SEASON_NAMES_CN = {
+    1: "永久服",
+    1301: "SS11 灭世之喉",
+    1401: "SS12 月华",
+}
+
+
+# Hero ID to Chinese name mapping
+HERO_NAMES_CN = {
+    1100: "雷汉",
+    1200: "卡里诺",
+    1300: "吉玛",
+    1400: "游厄",
+    1500: "莫托",
+    1600: "伊莉丝",
+    1700: "妮亚",
+    1800: "艾莉卡",
+    1900: "冰",
+    2000: "奥拉克尔",
+    2100: "莱昂",
+    2200: "貓眼",
 }
 
 

--- a/src/titrack/web/static/app.js
+++ b/src/titrack/web/static/app.js
@@ -403,7 +403,7 @@ async function checkLowSupplyAlerts() {
         const alertKey = String(item.config_base_id);
 
         if (item.quantity <= threshold && !supplyAlertedCategories.has(alertKey)) {
-            showToast(`Low Supply: ${item.name} — ${item.quantity} remaining (threshold: ${threshold})`, 'warning');
+            showToast(t('toast.low_supply', { name: pickItemName(item), qty: item.quantity, threshold: threshold }), 'warning');
             supplyAlertedCategories.add(alertKey);
         } else if (item.quantity > threshold && supplyAlertedCategories.has(alertKey)) {
             // Re-arm alert when quantity goes back above threshold
@@ -723,7 +723,7 @@ function buildCostTooltip(costItems) {
         const value = item.total_value_fe !== null
             ? `${item.total_value_fe.toFixed(2)} FE`
             : '? FE';
-        return `${item.name} x${qty} = ${value}`;
+        return t('misc.cost_line', { name: pickItemName(item), qty: qty, value: value });
     });
     // Escape for HTML attribute and use newline character
     return escapeAttr(lines.join('\n'));
@@ -863,7 +863,7 @@ function renderRuns(data, forceRender = false) {
 
         return `
             <tr class="${nightmareClass}${ignoredClass}">
-                <td class="zone-name" title="${run.zone_signature}${consolidatedInfo}">${escapeHtml(run.zone_name)}</td>
+                <td class="zone-name" title="${run.zone_signature}${consolidatedInfo}">${escapeHtml(tZone(run.zone_name))}</td>
                 <td class="duration">${formatDuration(run.duration_seconds)}</td>
                 <td>${valueDisplay}</td>
                 <td>
@@ -917,7 +917,7 @@ function renderActiveRun(data, forceRender = false) {
 
     // Show panel and update content
     panel.classList.remove('hidden');
-    zoneEl.textContent = data.zone_name;
+    zoneEl.textContent = tZone(data.zone_name);
     durationEl.textContent = `(${formatDuration(data.duration_seconds)})`;
 
     // Show value with cost info if map costs are enabled
@@ -951,7 +951,7 @@ function renderActiveRun(data, forceRender = false) {
             return `
                 <div class="loot-item${negativeClass}">
                     ${iconHtml}
-                    <span class="loot-name">${escapeHtml(item.name)}</span>
+                    <span class="loot-name">${escapeHtml(pickItemName(item))}</span>
                     <span class="loot-qty">${qtyPrefix}${item.quantity}</span>
                     <span class="loot-value">${valueText}</span>
                 </div>
@@ -1013,7 +1013,7 @@ function renderInventory(data, forceRender = false) {
                 <td>
                     <div class="item-row">
                         ${iconHtml}
-                        <a href="https://titrack.ninja/item/${item.config_base_id}" target="_blank" class="item-name item-name-link ${isFE ? 'fe' : ''}">${escapeHtml(item.name)}${cloudIndicator}</a>
+                        <a href="${pickItemUrl(item) || ('https://titrack.ninja/item/' + item.config_base_id)}" target="_blank" class="item-name item-name-link ${isFE ? 'fe' : ''}">${escapeHtml(pickItemName(item))}${cloudIndicator}</a>
                     </div>
                 </td>
                 <td>${formatNumber(item.quantity)}</td>
@@ -1199,10 +1199,10 @@ function renderStatus(status) {
 
     if (status?.collector_running) {
         indicator.classList.add('active');
-        collectorStatus.textContent = 'Collector: Running';
+        collectorStatus.textContent = t('footer.collector', { state: t('footer.collector_running') });
     } else {
         indicator.classList.remove('active');
-        collectorStatus.textContent = 'Collector: Stopped';
+        collectorStatus.textContent = t('footer.collector', { state: t('footer.collector_stopped') });
     }
 
     // Show/hide awaiting player summary (inline header).
@@ -1358,7 +1358,7 @@ function renderPlayer(player) {
 
     if (player) {
         playerName.textContent = player.name;
-        playerDetails.textContent = player.season_name;
+        playerDetails.textContent = pickSeasonName(player);
         playerInfo.classList.remove('hidden');
     } else {
         playerInfo.classList.add('hidden');
@@ -1538,6 +1538,14 @@ async function openSettingsModal(prefillLogPath) {
     document.getElementById('settings-supply-beacon').value = supplyAlertThresholds.beacons;
     document.getElementById('settings-supply-compass').value = supplyAlertThresholds.compasses;
     document.getElementById('settings-supply-resonance').value = supplyAlertThresholds.resonance;
+
+    // Load current language
+    try {
+        const langSel = document.getElementById('settings-language');
+        if (langSel) {
+            langSel.value = (typeof i18n !== 'undefined' && i18n.getLang()) || 'en';
+        }
+    } catch (_) { /* ignore */ }
 
     // Fetch current log path from status
     try {
@@ -1944,7 +1952,7 @@ async function showRunDetails(runId) {
     const title = document.getElementById('modal-title');
     const body = document.getElementById('modal-body');
 
-    title.textContent = `${run.zone_name} - ${formatDuration(run.duration_seconds)}`;
+    title.textContent = `${tZone(run.zone_name)} - ${formatDuration(run.duration_seconds)}`;
 
     // Track ignored items state for this modal
     const ignoredItems = new Set(run.ignored_items || []);
@@ -1982,7 +1990,7 @@ async function showRunDetails(runId) {
                         <li class="loot-item${itemIgnoredClass}" data-config-id="${item.config_base_id}">
                             <div class="loot-item-name">
                                 ${iconHtml}
-                                <span>${escapeHtml(item.name)}</span>
+                                <span>${escapeHtml(pickItemName(item))}</span>
                             </div>
                             <div class="loot-item-values">
                                 <span class="loot-item-qty ${item.total_value_fe !== null ? (item.total_value_fe > 0 ? 'positive' : 'negative') : ''}">${valueStr}</span>
@@ -2227,7 +2235,7 @@ function renderHideItemsTable() {
     const pending = modal._pendingHidden || new Set();
 
     if (searchTerm) {
-        items = items.filter(item => item.name.toLowerCase().includes(searchTerm));
+        items = items.filter(item => pickItemName(item).toLowerCase().includes(searchTerm));
     }
 
     // Sort
@@ -2252,7 +2260,7 @@ function renderHideItemsTable() {
             <tr class="${checked ? 'hide-items-row-hidden' : ''}">
                 <td><input type="checkbox" data-id="${item.config_base_id}" ${checked ? 'checked' : ''}
                     onchange="toggleHideItem(${item.config_base_id}, this.checked)"></td>
-                <td><div class="item-name-cell">${iconHtml}<span>${escapeHtml(item.name)}</span></div></td>
+                <td><div class="item-name-cell">${iconHtml}<span>${escapeHtml(pickItemName(item))}</span></div></td>
                 <td>${formatNumber(item.quantity)}</td>
                 <td>${valueStr}</td>
             </tr>`;
@@ -2395,7 +2403,7 @@ async function showLootReport() {
                 <td>
                     <div class="item-col">
                         ${iconHtml}
-                        <a href="https://titrack.ninja/item/${item.config_base_id}" target="_blank" class="item-name-link">${escapeHtml(item.name)}</a>
+                        <a href="${pickItemUrl(item) || ('https://titrack.ninja/item/' + item.config_base_id)}" target="_blank" class="item-name-link">${escapeHtml(pickItemName(item))}</a>
                     </div>
                 </td>
                 <td>${formatNumber(item.quantity)}</td>
@@ -2518,7 +2526,7 @@ function renderLootReportChart(data) {
     const top10 = pricedItems.slice(0, 10);
     const others = pricedItems.slice(10);
 
-    const labels = top10.map(item => item.name);
+    const labels = top10.map(item => pickItemName(item));
     const values = top10.map(item => item.total_value_fe);
 
     // Add "Other" category if there are more items
@@ -2774,12 +2782,12 @@ async function resetStats() {
 
     const btn = document.getElementById('reset-stats-btn');
     btn.disabled = true;
-    btn.textContent = 'Resetting...';
+    btn.textContent = t('controls.resetting');
 
     const result = await postResetStats();
 
     btn.disabled = false;
-    btn.textContent = 'Reset Stats';
+    btn.textContent = t('controls.reset_stats');
 
     if (result && result.success) {
         // Clear chart data hashes to force re-render
@@ -3221,6 +3229,33 @@ async function exitApp() {
 // --- Initialization ---
 
 document.addEventListener('DOMContentLoaded', async () => {
+    // Apply persisted language to static text BEFORE first render. Try to
+    // sync with the server-side `language` setting (this may override the
+    // localStorage cache if the user changed language on another device).
+    try {
+        const resp = await fetch(`${API_BASE}/settings/language`);
+        if (resp.ok) {
+            const data = await resp.json();
+            if (data && data.value) {
+                i18n.setLang(data.value);
+            }
+        }
+    } catch (_) { /* offline-friendly */ }
+
+    // Re-render dynamic content when the language changes.
+    document.addEventListener('langchange', () => {
+        try {
+            i18n.loadZoneTranslations().then(() => {
+                if (typeof refreshAll === 'function') refreshAll(true);
+                if (typeof fetchPlayer === 'function') {
+                    fetchPlayer().then(p => {
+                        if (typeof renderPlayer === 'function') renderPlayer(p);
+                    });
+                }
+            });
+        } catch (e) { console.error('langchange handler:', e); }
+    });
+
     // Set initial sort indicators
     updateSortIndicators();
 
@@ -3258,6 +3293,23 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Set up settings modal toggles
     const settingsTradeTaxToggle = document.getElementById('settings-trade-tax');
     settingsTradeTaxToggle.addEventListener('change', handleTradeTaxToggle);
+    // Wire language <select>: persist to server and switch UI language.
+    const settingsLanguage = document.getElementById('settings-language');
+    if (settingsLanguage) {
+        settingsLanguage.addEventListener('change', async (e) => {
+            const lang = e.target.value || 'en';
+            try {
+                await fetch(`${API_BASE}/settings/language`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ value: lang }),
+                });
+            } catch (err) {
+                console.error('Failed to save language setting:', err);
+            }
+            i18n.setLang(lang);
+        });
+    }
 
     const settingsMapCostsToggle = document.getElementById('settings-map-costs');
     settingsMapCostsToggle.addEventListener('change', handleMapCostsToggle);

--- a/src/titrack/web/static/i18n.js
+++ b/src/titrack/web/static/i18n.js
@@ -1,0 +1,681 @@
+/**
+ * TITrack i18n module - English / Simplified Chinese
+ *
+ * Public API:
+ *   t(key, vars?)         -> translate a key with optional {var} substitution
+ *   pickItemName(item)    -> CN name if zh-CN and available, else EN, else "Unknown {id}"
+ *   pickItemUrl(item)     -> CN url if zh-CN and available, else EN
+ *   tZone(englishName)    -> zone translation if available, else englishName
+ *   pickSeasonName(player)-> CN season if zh-CN and available, else EN
+ *   pickHeroName(player)  -> CN hero if zh-CN and available, else EN
+ *   setLang(lang)         -> change language and dispatch 'langchange' event
+ *   getLang()             -> 'en' | 'zh-CN'
+ *   applyTranslations(root?) -> walk DOM and update [data-i18n] / [data-i18n-title] / [data-i18n-placeholder]
+ *
+ * Translation tables are flat key → string maps. Missing keys fall back to
+ * English; missing English fall back to the key string itself.
+ */
+(function (global) {
+    'use strict';
+
+    const TRANSLATIONS = {
+        'en': {
+            // Header
+            'header.app_title': 'TITrack',
+            'header.awaiting_player': 'Waiting for character detection... (log in or sort your inventory)',
+            'header.see_details': 'See details',
+            'header.net_worth': 'Net Worth',
+            'header.cumulative_value': 'Cumulative Value',
+            'header.fe_per_hour': 'FE/Hour',
+            'header.fe_per_map': 'FE/Map',
+            'header.runs': 'Runs',
+            'header.avg_run_time': 'Avg Run Time',
+            'header.total_time': 'Total Time',
+            'header.fe_per_hour_tooltip': 'Calculated from active run time only. Time spent in town, hideout, or between runs is not counted. This measures your farming efficiency, not total session time.',
+            'header.pause_tracking': 'Pause tracking',
+            'header.resume_tracking': 'Resume tracking',
+            // Controls
+            'controls.overlay': 'Overlay',
+            'controls.overlay_tooltip': 'Open mini overlay',
+            'controls.economy': 'Economy',
+            'controls.economy_tooltip': 'Open titrack.ninja economy data',
+            'controls.cloud_sync': 'Cloud Sync',
+            'controls.cloud_sync_tooltip': 'Cloud sync status',
+            'controls.settings': 'Settings',
+            'controls.instructions': 'Instructions',
+            'controls.reset_stats': 'Reset Stats',
+            'controls.resetting': 'Resetting...',
+            'controls.auto_refresh': 'Auto-refresh',
+            // Charts
+            'charts.cumulative_value': 'Cumulative Value',
+            'charts.fe_per_hour': 'FE / Hour',
+            // Active run
+            'active_run.title_prefix': 'Current Run:',
+            'active_run.value': 'Value:',
+            'active_run.no_drops': 'No drops yet...',
+            'active_run.previous_run': 'Previous Run',
+            // Recent runs
+            'runs.title': 'Recent Runs',
+            'runs.report': 'Report',
+            'runs.col_zone': 'Zone',
+            'runs.col_duration': 'Duration',
+            'runs.col_value': 'Value',
+            'runs.loading': 'Loading...',
+            'runs.none': 'No runs recorded yet',
+            'runs.details': 'Details',
+            'runs.gross': 'gross:',
+            'runs.cost': 'cost:',
+            // Inventory
+            'inventory.title': 'Current Inventory',
+            'inventory.hide_items': 'Hide Items',
+            'inventory.hide_items_count': 'Hide Items ({count})',
+            'inventory.col_item': 'Item',
+            'inventory.col_qty': 'Qty',
+            'inventory.col_value': 'Value',
+            'inventory.col_trend': 'Trend',
+            'inventory.trend_tooltip': 'Price trend (72h)',
+            'inventory.filter_tooltip': 'Filter by tab',
+            'inventory.tab_all': 'All',
+            'inventory.tab_gear': 'Gear',
+            'inventory.tab_skill': 'Skill',
+            'inventory.tab_commodity': 'Commodity',
+            'inventory.tab_others': 'Others',
+            'inventory.empty': 'No items in inventory',
+            // Footer
+            'footer.last_updated': 'Last updated: {time}',
+            'footer.collector': 'Collector: {state}',
+            'footer.collector_running': 'Running',
+            'footer.collector_stopped': 'Stopped',
+            'footer.discord_tooltip': 'Join the TITrack Discord',
+            'footer.kofi_tooltip': 'Help cover server costs',
+            'footer.kofi': 'Help cover server costs',
+            'footer.check_updates': 'Check for Updates',
+            'footer.update_tooltip': 'Update available',
+            'footer.exit': 'Exit App',
+            'footer.checking': 'Checking...',
+            'footer.update_available': 'Update Available!',
+            'footer.downloading': 'Downloading...',
+            'footer.install_update': 'Install Update',
+            // Run details modal
+            'modal.run_details': 'Run Details',
+            'modal.ignore_run': '✕ Ignore Run',
+            'modal.run_ignored': '✓ Run Ignored',
+            // Settings modal
+            'settings.title': 'Settings',
+            'settings.section_value': 'Value Calculations',
+            'settings.trade_tax': 'Trade Tax',
+            'settings.trade_tax_desc': 'Apply 12.5% trade house tax to item values',
+            'settings.map_costs': 'Map Costs',
+            'settings.map_costs_desc': 'Track and subtract compass/beacon costs from run values',
+            'settings.realtime': 'Real-Time Tracking',
+            'settings.realtime_desc': 'Use wall-clock time for FE/Hour and Total Time instead of in-map time only',
+            'settings.section_overlay': 'Overlay',
+            'settings.overlay_hide_loot': 'Hide Loot Pickups',
+            'settings.overlay_hide_loot_desc': 'Hide the loot section in the overlay for a more compact view (stats only)',
+            'settings.overlay_micro': 'Micro Overlay',
+            'settings.overlay_micro_desc': 'Show a compact overlay with only key stats instead of the full overlay',
+            'settings.layout': 'Layout:',
+            'settings.layout_horizontal': 'Horizontal',
+            'settings.layout_vertical': 'Vertical',
+            'settings.font_size': 'Font size:',
+            'settings.visible_stats': 'Visible stats:',
+            'settings.drag_to_reorder': '(drag to reorder)',
+            'settings.section_supply': 'Low Supply Alerts',
+            'settings.supply_desc': 'Get notified when map supplies drop to a threshold. Set to 0 to disable.',
+            'settings.supply_beacons': 'Beacons',
+            'settings.supply_compasses': 'Compasses',
+            'settings.supply_resonance': 'Resonance',
+            'settings.section_game_dir': 'Game Directory',
+            'settings.current_path': 'Current:',
+            'settings.path_placeholder': 'C:\\Torchlight Infinite or C:\\...\\Logs\\UE_game.log',
+            'settings.browse': 'Browse',
+            'settings.validate': 'Validate',
+            'settings.path_help': 'You can enter the game folder, the Logs folder, or the full path to UE_game.log',
+            'settings.save_restart': 'Save & Restart',
+            'settings.saved_restart_required': 'Saved - Restart Required',
+            'settings.saving': 'Saving...',
+            'settings.section_language': 'Language',
+            'settings.language_label': 'Language',
+            'settings.language_desc': 'Display language for the dashboard and overlay',
+            'settings.path_validating': 'Validating...',
+            'settings.path_enter': 'Please enter a path',
+            'settings.path_found': 'Found: {path}',
+            'settings.path_not_found': 'Log file not found at this location',
+            'settings.path_error': 'Error validating path. Please try again.',
+            'settings.path_loading': 'Loading...',
+            'settings.path_not_found_short': 'Not found - please configure below',
+            'settings.path_unable': 'Unable to fetch current path',
+            'settings.saved_msg': 'Saved! Please restart TITrack for changes to take effect.',
+            'settings.error_saving': 'Error saving. Please try again.',
+            // Loot report
+            'report.title': 'Loot Report',
+            'report.gross': 'Gross Value',
+            'report.map_costs': 'Map Costs',
+            'report.profit': 'Profit',
+            'report.runs': 'Runs',
+            'report.total_time': 'Total Time',
+            'report.profit_per_hour': 'Profit/Hour',
+            'report.profit_per_map': 'Profit/Map',
+            'report.unique_items': 'Unique Items',
+            'report.col_item': 'Item',
+            'report.col_qty': 'Qty',
+            'report.col_unit_price': 'Unit Price',
+            'report.col_total_value': 'Total Value',
+            'report.col_pct': '%',
+            'report.export_csv': 'Export CSV',
+            'report.close': 'Close',
+            'report.loading': 'Loading report...',
+            'report.failed': 'Failed to load report',
+            'report.empty': 'No loot recorded yet. Complete some runs to see your report.',
+            // Hide items modal
+            'hide.title': 'Hide Items from Inventory',
+            'hide.hint': 'Check items to hide from inventory display. Hidden items still count toward net worth.',
+            'hide.hint_excluded': 'Check items to hide from inventory display. Hidden items will be excluded from net worth.',
+            'hide.exclude_worth': 'Exclude from Net Worth',
+            'hide.exclude_worth_desc': 'Hidden items will not count toward net worth',
+            'hide.search': 'Search items...',
+            'hide.col_item': 'Item',
+            'hide.col_qty': 'Qty',
+            'hide.col_value': 'Value',
+            'hide.save': 'Save',
+            'hide.cancel': 'Cancel',
+            'hide.count': '{count} item{plural} hidden',
+            'hide.empty': 'No items in inventory',
+            // Update modal
+            'update.title': 'Update Available',
+            'update.release_notes': 'Release Notes',
+            'update.loading': 'Loading...',
+            'update.no_notes': 'No release notes available.',
+            'update.download_install': 'Download & Install',
+            'update.later': 'Later',
+            'update.downloading_progress': 'Downloading... {mb} / {total} MB',
+            'update.installing': 'Download complete. Installing...',
+            'update.ready_install': 'Ready to install',
+            'update.failed': 'Download failed: {error}',
+            'update.retry': 'Retry',
+            'update.unknown_error': 'Unknown error',
+            'update.shutdown': 'TITrack has been shut down. You can close this tab.',
+            // Help modal
+            'help.title': 'How to Use TITrack',
+            'help.s1.title': '1. Enable Game Logging',
+            'help.s1.intro': "TITrack reads the game's log file to track your loot. To enable logging:",
+            'help.s1.step1': 'Open Torchlight Infinite',
+            'help.s1.step2': 'Go to <strong>Settings</strong>',
+            'help.s1.step3': 'Find and click the <strong>"Enable Log"</strong> button',
+            'help.s1.note': 'Without this enabled, TITrack cannot capture any data.',
+            'help.s2.title': '2. Character Detection',
+            'help.s2.intro': 'TITrack automatically detects your character from the game log:',
+            'help.s2.b1': "If you've played before with logging enabled, your character is detected <strong>automatically</strong> on startup",
+            'help.s2.b2': 'If this is your first time, log in with your character and TITrack will detect it',
+            'help.s2.b3': 'To switch characters, just log out and back in (do NOT close the game)',
+            'help.s2.note': 'TITrack tracks data separately for each character and league.',
+            'help.s3.title': '3. Sync Your Inventory',
+            'help.s3.intro': 'To populate the inventory display with your current items:',
+            'help.s3.step1': 'Open your inventory in-game',
+            'help.s3.step2': 'Click the <strong>Sort</strong> button (auto-arranges items)',
+            'help.s3.step3': 'Repeat for each tab you want to track (Skill, Commodity, Others)',
+            'help.s3.note': 'The Gear tab is not tracked because gear prices depend heavily on specific affixes.',
+            'help.s4.title': '4. Automatic Price Learning',
+            'help.s4.intro': 'TITrack learns item prices automatically when you use the in-game Exchange:',
+            'help.s4.step1': 'Open the Exchange in-game',
+            'help.s4.step2': 'Search for any item you want to price',
+            'help.s4.step3': 'TITrack captures the listed prices and calculates a reference price (10th percentile)',
+            'help.s4.note': 'Prices are saved locally and used to calculate your loot value and net worth.',
+            'help.s5.title': '5. Tracking Runs',
+            'help.s5.intro': 'Once logging is enabled, TITrack automatically:',
+            'help.s5.b1': 'Detects when you enter and leave maps',
+            'help.s5.b2': 'Tracks all items picked up during each run',
+            'help.s5.b3': 'Calculates value based on learned prices',
+            'help.s5.b4': 'Shows your FE/Hour based on active run time only',
+            'help.s6.title': '6. Cloud Sync (Optional)',
+            'help.s6.intro': 'Share and receive community pricing data by enabling Cloud Sync:',
+            'help.s6.step1': 'Click the <strong>Cloud Sync</strong> toggle in the header',
+            'help.s6.step2': 'When enabled, your Exchange searches are anonymously shared',
+            'help.s6.step3': "You'll receive aggregated prices from other users",
+            'help.s6.benefits': 'Benefits:',
+            'help.s6.b1': "Get prices for items you haven't searched yet",
+            'help.s6.b2': 'See price trends with sparkline charts',
+            'help.s6.b3': 'Help the community by contributing your data',
+            'help.s6.note': 'Cloud Sync is completely optional and anonymous. No account required. Only Exchange prices are shared, never manual edits. Data requires 3+ contributors before being shown.',
+            // No-character modal
+            'nochar.title': 'Character Not Detected',
+            'nochar.dismiss': 'Dismiss',
+            'nochar.diagnostics': 'Diagnostics',
+            'nochar.checking': 'Checking log activity...',
+            'nochar.detect_title': 'How character detection works',
+            'nochar.detect_intro': "TITrack reads your character name and season from the game log, but Torchlight only writes those details when its <strong>Enable Log</strong> setting is on <em>at the exact moment</em> the game's login-time data packet arrives. Enabling the log after you're already logged in is not enough — you need to trigger a new login while the log is on.",
+            'nochar.try_title': 'Try this first',
+            'nochar.try_step1': 'Open Torchlight Infinite and log in to your character as usual.',
+            'nochar.try_step2': 'Open the in-game <strong>Settings</strong> menu and turn on <strong>Enable Log</strong>.',
+            'nochar.try_step3': "Exit all the way back to the <strong>Select Character</strong> screen (you don't need to quit the client).",
+            'nochar.try_step4': 'Click your character to log back in.',
+            'nochar.try_note': 'This works because the server re-sends your full character data on every login, and Torchlight only writes it to the log when Enable Log is already on when that packet arrives.',
+            'nochar.fail_title': "If that didn't work",
+            'nochar.fail_intro': 'On some sessions the game records only a truncated placeholder (<code>+player+...</code>) for your character even with logging on. Resetting the client usually clears this:',
+            'nochar.fail_step1': 'Fully close Torchlight Infinite (quit to desktop — not just log out).',
+            'nochar.fail_step2': 'Reopen the client and log in to your character.',
+            'nochar.fail_step3': 'Open <strong>Settings</strong> and turn on <strong>Enable Log</strong>.',
+            'nochar.fail_step4': 'Exit to <strong>Select Character</strong> and log back in.',
+            'nochar.fail_note': "A sort of your inventory (click the Sort button in your bag) also forces a fresh inventory dump, which is a useful extra nudge if detection still doesn't fire.",
+            'nochar.other_title': 'Other things to check',
+            'nochar.other_b1': "<strong>Wrong log file.</strong> If you have both the Steam and standalone Torchlight client installed, TITrack may be watching the log for the client you aren't currently playing on. The diagnostic above will suggest a switch when it detects a newer log elsewhere.",
+            'nochar.other_b2': "<strong>Game closed.</strong> Torchlight only writes to its log while it's running. If you quit the game, the log stops updating and TITrack will flag it as stale.",
+            'nochar.other_b3': "<strong>Enable Log doesn't persist.</strong> Torchlight resets this toggle to off every time the client restarts. You need to turn it back on each session.",
+            // Toasts / misc
+            'toast.low_supply': 'Low Supply: {name} — {qty} remaining (threshold: {threshold})',
+            'toast.exported_to': 'Exported to {file}',
+            'unit.fe': 'FE',
+            'unit.fe_per_hour': 'FE/Hour',
+            'unit.fe_per_map': 'FE/Map',
+            'misc.unknown_item': 'Unknown {id}',
+            // Cost tooltip line: "Item x123 = 456"
+            'misc.cost_line': '{name} x{qty} = {value}',
+        },
+        'zh-CN': {
+            // Header
+            'header.app_title': 'TITrack',
+            'header.awaiting_player': '正在等待识别角色…（请登录游戏或整理一下背包）',
+            'header.see_details': '查看详情',
+            'header.net_worth': '净资产',
+            'header.cumulative_value': '累计价值',
+            'header.fe_per_hour': '源质/小时',
+            'header.fe_per_map': '源质/图',
+            'header.runs': '地图数',
+            'header.avg_run_time': '平均时间',
+            'header.total_time': '总时长',
+            'header.fe_per_hour_tooltip': '仅以游戏内地图运行时间为基准计算，城镇、驻地及地图间的等待时间不计入。此值反映打图效率，而非整体游戏时长。',
+            'header.pause_tracking': '暂停统计',
+            'header.resume_tracking': '继续统计',
+            // Controls
+            'controls.overlay': '悬浮窗',
+            'controls.overlay_tooltip': '打开迷你悬浮窗',
+            'controls.economy': '经济数据',
+            'controls.economy_tooltip': '打开 titrack.ninja 经济数据',
+            'controls.cloud_sync': '云端同步',
+            'controls.cloud_sync_tooltip': '云端同步状态',
+            'controls.settings': '设置',
+            'controls.instructions': '使用说明',
+            'controls.reset_stats': '重置统计',
+            'controls.resetting': '正在重置…',
+            'controls.auto_refresh': '自动刷新',
+            // Charts
+            'charts.cumulative_value': '累计价值',
+            'charts.fe_per_hour': '源质 / 小时',
+            // Active run
+            'active_run.title_prefix': '当前地图：',
+            'active_run.value': '价值：',
+            'active_run.no_drops': '暂无掉落…',
+            'active_run.previous_run': '上一张地图',
+            // Recent runs
+            'runs.title': '最近地图',
+            'runs.report': '报表',
+            'runs.col_zone': '地区',
+            'runs.col_duration': '耗时',
+            'runs.col_value': '价值',
+            'runs.loading': '加载中…',
+            'runs.none': '暂无地图记录',
+            'runs.details': '详情',
+            'runs.gross': '总收益：',
+            'runs.cost': '消耗：',
+            // Inventory
+            'inventory.title': '当前背包',
+            'inventory.hide_items': '隐藏物品',
+            'inventory.hide_items_count': '隐藏物品（{count}）',
+            'inventory.col_item': '物品',
+            'inventory.col_qty': '数量',
+            'inventory.col_value': '价值',
+            'inventory.col_trend': '趋势',
+            'inventory.trend_tooltip': '价格趋势（72小时）',
+            'inventory.filter_tooltip': '按背包页筛选',
+            'inventory.tab_all': '全部',
+            'inventory.tab_gear': '装备',
+            'inventory.tab_skill': '技能',
+            'inventory.tab_commodity': '通货',
+            'inventory.tab_others': '杂项',
+            'inventory.empty': '背包为空',
+            // Footer
+            'footer.last_updated': '最后更新：{time}',
+            'footer.collector': '采集器：{state}',
+            'footer.collector_running': '运行中',
+            'footer.collector_stopped': '已停止',
+            'footer.discord_tooltip': '加入 TITrack 的 Discord',
+            'footer.kofi_tooltip': '帮助分担服务器费用',
+            'footer.kofi': '帮助分担服务器费用',
+            'footer.check_updates': '检查更新',
+            'footer.update_tooltip': '有可用更新',
+            'footer.exit': '退出程序',
+            'footer.checking': '检查中…',
+            'footer.update_available': '有可用更新！',
+            'footer.downloading': '下载中…',
+            'footer.install_update': '安装更新',
+            // Run details modal
+            'modal.run_details': '地图详情',
+            'modal.ignore_run': '✕ 忽略此地图',
+            'modal.run_ignored': '✓ 已忽略此地图',
+            // Settings modal
+            'settings.title': '设置',
+            'settings.section_value': '价值计算',
+            'settings.trade_tax': '交易税',
+            'settings.trade_tax_desc': '对物品价值应用 12.5% 的交易行税率',
+            'settings.map_costs': '地图开销',
+            'settings.map_costs_desc': '统计并扣除指南针/信标等开图消耗',
+            'settings.realtime': '实时计时',
+            'settings.realtime_desc': '使用真实时间计算 源质/小时 与 总时长（而非仅游戏内地图时间）',
+            'settings.section_overlay': '悬浮窗',
+            'settings.overlay_hide_loot': '隐藏掉落列表',
+            'settings.overlay_hide_loot_desc': '在悬浮窗中隐藏掉落区域，使界面更紧凑（仅显示数据）',
+            'settings.overlay_micro': '迷你悬浮窗',
+            'settings.overlay_micro_desc': '改用紧凑模式仅显示关键数据',
+            'settings.layout': '布局：',
+            'settings.layout_horizontal': '横向',
+            'settings.layout_vertical': '纵向',
+            'settings.font_size': '字号：',
+            'settings.visible_stats': '显示项：',
+            'settings.drag_to_reorder': '（可拖拽排序）',
+            'settings.section_supply': '低库存提醒',
+            'settings.supply_desc': '当开图消耗品的数量低于阈值时提醒，设为 0 表示不提醒。',
+            'settings.supply_beacons': '信标',
+            'settings.supply_compasses': '指南针',
+            'settings.supply_resonance': '共振石',
+            'settings.section_game_dir': '游戏目录',
+            'settings.current_path': '当前路径：',
+            'settings.path_placeholder': 'C:\\Torchlight Infinite 或 C:\\…\\Logs\\UE_game.log',
+            'settings.browse': '浏览',
+            'settings.validate': '校验',
+            'settings.path_help': '可填写游戏目录、Logs 文件夹或 UE_game.log 的完整路径',
+            'settings.save_restart': '保存并重启',
+            'settings.saved_restart_required': '已保存 - 需要重启',
+            'settings.saving': '保存中…',
+            'settings.section_language': '语言',
+            'settings.language_label': '语言',
+            'settings.language_desc': '面板与悬浮窗的显示语言',
+            'settings.path_validating': '校验中…',
+            'settings.path_enter': '请填写一个路径',
+            'settings.path_found': '已找到：{path}',
+            'settings.path_not_found': '在该位置未找到日志文件',
+            'settings.path_error': '校验失败，请重试。',
+            'settings.path_loading': '加载中…',
+            'settings.path_not_found_short': '未找到 - 请在下方配置',
+            'settings.path_unable': '无法获取当前路径',
+            'settings.saved_msg': '已保存！请重启 TITrack 使更改生效。',
+            'settings.error_saving': '保存失败，请重试。',
+            // Loot report
+            'report.title': '掉落报表',
+            'report.gross': '总价值',
+            'report.map_costs': '地图开销',
+            'report.profit': '利润',
+            'report.runs': '地图数',
+            'report.total_time': '总时长',
+            'report.profit_per_hour': '利润/小时',
+            'report.profit_per_map': '利润/图',
+            'report.unique_items': '物品种类',
+            'report.col_item': '物品',
+            'report.col_qty': '数量',
+            'report.col_unit_price': '单价',
+            'report.col_total_value': '总价值',
+            'report.col_pct': '%',
+            'report.export_csv': '导出 CSV',
+            'report.close': '关闭',
+            'report.loading': '正在加载报表…',
+            'report.failed': '加载报表失败',
+            'report.empty': '暂无掉落数据，完成几张地图后再查看报表。',
+            // Hide items modal
+            'hide.title': '从背包中隐藏物品',
+            'hide.hint': '勾选要从背包中隐藏的物品。隐藏的物品仍计入净资产。',
+            'hide.hint_excluded': '勾选要从背包中隐藏的物品。隐藏的物品不会计入净资产。',
+            'hide.exclude_worth': '从净资产中排除',
+            'hide.exclude_worth_desc': '隐藏的物品不会计入净资产',
+            'hide.search': '搜索物品…',
+            'hide.col_item': '物品',
+            'hide.col_qty': '数量',
+            'hide.col_value': '价值',
+            'hide.save': '保存',
+            'hide.cancel': '取消',
+            'hide.count': '已隐藏 {count} 个物品',
+            'hide.empty': '背包为空',
+            // Update modal
+            'update.title': '有可用更新',
+            'update.release_notes': '更新说明',
+            'update.loading': '加载中…',
+            'update.no_notes': '暂无更新说明。',
+            'update.download_install': '下载并安装',
+            'update.later': '稍后',
+            'update.downloading_progress': '下载中… {mb} / {total} MB',
+            'update.installing': '下载完成，正在安装…',
+            'update.ready_install': '准备安装',
+            'update.failed': '下载失败：{error}',
+            'update.retry': '重试',
+            'update.unknown_error': '未知错误',
+            'update.shutdown': 'TITrack 已关闭，可以关闭此标签页了。',
+            // Help modal
+            'help.title': '如何使用 TITrack',
+            'help.s1.title': '1. 开启游戏日志',
+            'help.s1.intro': 'TITrack 通过读取游戏日志文件来追踪你的掉落。开启方式：',
+            'help.s1.step1': '打开《无限火炬》',
+            'help.s1.step2': '进入 <strong>设置</strong>',
+            'help.s1.step3': '找到并点击 <strong>"启用日志"</strong> 按钮',
+            'help.s1.note': '不开启此选项的话，TITrack 无法采集任何数据。',
+            'help.s2.title': '2. 角色识别',
+            'help.s2.intro': 'TITrack 会自动从游戏日志中识别你的角色：',
+            'help.s2.b1': '如果你之前在开启日志的情况下游玩过，启动时会 <strong>自动</strong> 识别你的角色',
+            'help.s2.b2': '如果是首次使用，登录角色后 TITrack 会自动识别',
+            'help.s2.b3': '切换角色只需登出再登入即可（不要关闭游戏）',
+            'help.s2.note': 'TITrack 会按角色和赛季分别保存数据。',
+            'help.s3.title': '3. 同步背包',
+            'help.s3.intro': '让背包面板显示当前物品的方法：',
+            'help.s3.step1': '在游戏内打开背包',
+            'help.s3.step2': '点击 <strong>整理</strong> 按钮（自动排列物品）',
+            'help.s3.step3': '在每个需要追踪的页签重复操作（技能、商品、其他）',
+            'help.s3.note': '装备页不会被追踪，因为装备价格高度依赖于具体词缀。',
+            'help.s4.title': '4. 自动学习价格',
+            'help.s4.intro': '当你在游戏内使用交易行时，TITrack 会自动学习物品价格：',
+            'help.s4.step1': '在游戏内打开交易行',
+            'help.s4.step2': '搜索你想要定价的任意物品',
+            'help.s4.step3': 'TITrack 会捕获挂单价格，并以第 10 百分位作为参考价',
+            'help.s4.note': '价格保存在本地，用于计算你的掉落价值与净资产。',
+            'help.s5.title': '5. 追踪打图',
+            'help.s5.intro': '开启日志后，TITrack 会自动：',
+            'help.s5.b1': '识别进入和离开地图',
+            'help.s5.b2': '追踪每张图中拾取的所有物品',
+            'help.s5.b3': '基于已学价格计算价值',
+            'help.s5.b4': '仅以地图运行时间为基准计算源质/小时',
+            'help.s6.title': '6. 云端同步（可选）',
+            'help.s6.intro': '通过开启云端同步来共享和接收社区价格数据：',
+            'help.s6.step1': '点击页头的 <strong>云端同步</strong> 开关',
+            'help.s6.step2': '开启后，你的交易行搜索会被匿名共享',
+            'help.s6.step3': '你将收到来自其他用户的聚合价格',
+            'help.s6.benefits': '好处：',
+            'help.s6.b1': '获得你尚未搜索过物品的价格',
+            'help.s6.b2': '通过迷你折线图查看价格趋势',
+            'help.s6.b3': '通过贡献数据帮助整个社区',
+            'help.s6.note': '云端同步完全可选且匿名，无需账户。仅共享交易行价格，绝不共享手工修改。数据需要至少 3 名贡献者后才会显示。',
+            // No-character modal
+            'nochar.title': '未识别到角色',
+            'nochar.dismiss': '关闭',
+            'nochar.diagnostics': '诊断信息',
+            'nochar.checking': '正在检查日志…',
+            'nochar.detect_title': '角色识别原理',
+            'nochar.detect_intro': 'TITrack 从游戏日志中读取你的角色名和赛季信息，但《无限火炬》仅在登录时数据包到达 <em>那一刻</em> 其 <strong>启用日志</strong> 选项已开启时，才会写入这些细节。已经登录后再开启日志是不够的——你需要在日志开启的状态下重新触发一次登录。',
+            'nochar.try_title': '请先尝试',
+            'nochar.try_step1': '正常打开《无限火炬》并登录角色。',
+            'nochar.try_step2': '打开游戏内 <strong>设置</strong> 菜单，开启 <strong>启用日志</strong>。',
+            'nochar.try_step3': '一路返回到 <strong>选择角色</strong> 界面（不需要退出客户端）。',
+            'nochar.try_step4': '点击角色重新登录。',
+            'nochar.try_note': '之所以有效，是因为服务器在每次登录时都会重新发送完整的角色数据，而《无限火炬》只在那个数据包到达时启用日志已开启的情况下才会写入。',
+            'nochar.fail_title': '如果上面的方法没用',
+            'nochar.fail_intro': '在某些会话中，即使开启了日志，游戏也只会记录一个被截断的占位符（<code>+player+...</code>）。重启客户端通常能清除这种状态：',
+            'nochar.fail_step1': '完全关闭《无限火炬》（退出到桌面，而不仅是登出）。',
+            'nochar.fail_step2': '重新打开客户端并登录角色。',
+            'nochar.fail_step3': '打开 <strong>设置</strong> 并开启 <strong>启用日志</strong>。',
+            'nochar.fail_step4': '退出到 <strong>选择角色</strong> 界面，再重新登录。',
+            'nochar.fail_note': '在背包中点击整理按钮也会强制游戏重新输出一次完整背包，如果识别仍然失败，这是一个有用的额外触发方式。',
+            'nochar.other_title': '其它需要排查的问题',
+            'nochar.other_b1': '<strong>日志文件不对。</strong> 如果你同时安装了 Steam 版和单机版的《无限火炬》，TITrack 可能正在监视你当前没在游玩的那个客户端的日志。当上方诊断信息检测到其它位置有更新的日志时，会建议切换。',
+            'nochar.other_b2': '<strong>游戏已关闭。</strong>《无限火炬》只在运行时才会写入日志。如果你退出了游戏，日志就会停止更新，TITrack 会将其标记为已过期。',
+            'nochar.other_b3': '<strong>"启用日志" 不会保留。</strong>《无限火炬》每次客户端重启时都会把这个开关重置为关闭状态。每次开机都需要重新打开。',
+            // Toasts / misc
+            'toast.low_supply': '低库存：{name} — 剩余 {qty}（阈值：{threshold}）',
+            'toast.exported_to': '已导出至 {file}',
+            'unit.fe': '源质',
+            'unit.fe_per_hour': '源质/小时',
+            'unit.fe_per_map': '源质/图',
+            'misc.unknown_item': '未知物品 {id}',
+            'misc.cost_line': '{name} x{qty} = {value}',
+        },
+    };
+
+    const SUPPORTED_LANGS = ['en', 'zh-CN'];
+    const STORAGE_KEY = 'titrack.lang';
+    let currentLang = 'en';
+    let zoneTranslations = {}; // {lang: {englishLabel: cnLabel}} — fetched from /api/i18n/zones
+
+    // Load cached preference synchronously so the very first render is correct.
+    try {
+        const cached = localStorage.getItem(STORAGE_KEY);
+        if (cached && SUPPORTED_LANGS.indexOf(cached) !== -1) {
+            currentLang = cached;
+        }
+    } catch (_) { /* localStorage may be unavailable */ }
+
+    function getLang() {
+        return currentLang;
+    }
+
+    function interpolate(str, vars) {
+        if (!vars || typeof str !== 'string') return str;
+        return str.replace(/\{(\w+)\}/g, function (_, k) {
+            return Object.prototype.hasOwnProperty.call(vars, k) ? String(vars[k]) : '{' + k + '}';
+        });
+    }
+
+    function t(key, vars) {
+        const dict = TRANSLATIONS[currentLang] || {};
+        const fallback = TRANSLATIONS.en || {};
+        const raw = (dict[key] !== undefined) ? dict[key] : (fallback[key] !== undefined ? fallback[key] : key);
+        return interpolate(raw, vars);
+    }
+
+    function pickItemName(item) {
+        if (!item) return '';
+        if (currentLang === 'zh-CN' && item.name_cn) return item.name_cn;
+        if (item.name_en) return item.name_en;
+        if (item.name) return item.name; // backwards-compat
+        if (item.config_base_id != null) return t('misc.unknown_item', { id: item.config_base_id });
+        return '';
+    }
+
+    function pickItemUrl(item) {
+        if (!item) return null;
+        if (currentLang === 'zh-CN' && item.url_cn) return item.url_cn;
+        return item.url_en || null;
+    }
+
+    function pickSeasonName(player) {
+        if (!player) return '';
+        if (currentLang === 'zh-CN' && player.season_name_cn) return player.season_name_cn;
+        return player.season_name_en || player.season_name || '';
+    }
+
+    function pickHeroName(player) {
+        if (!player) return '';
+        if (currentLang === 'zh-CN' && player.hero_name_cn) return player.hero_name_cn;
+        return player.hero_name_en || player.hero_name || '';
+    }
+
+    function tZone(englishName) {
+        if (!englishName) return englishName;
+        if (currentLang === 'en') return englishName;
+        const table = zoneTranslations[currentLang];
+        if (!table) return englishName;
+        // Direct hit
+        if (table[englishName]) return table[englishName];
+        // Handle " (Nightmare)" runtime suffix
+        const NM = ' (Nightmare)';
+        if (englishName.endsWith(NM)) {
+            const base = englishName.slice(0, -NM.length);
+            const tr = table[base];
+            const nmSuffix = table['(Nightmare)'] || NM;
+            return (tr ? tr : base) + nmSuffix;
+        }
+        return englishName;
+    }
+
+    async function loadZoneTranslations() {
+        if (zoneTranslations['zh-CN']) return; // already loaded
+        try {
+            const resp = await fetch('/api/i18n/zones');
+            if (resp.ok) {
+                zoneTranslations = await resp.json();
+            }
+        } catch (_) { /* offline-friendly: silently ignore */ }
+    }
+
+    function applyTranslations(root) {
+        const r = root || document;
+        // textContent
+        r.querySelectorAll('[data-i18n]').forEach(function (el) {
+            const key = el.getAttribute('data-i18n');
+            if (key) el.textContent = t(key);
+        });
+        // innerHTML (for strings containing <strong>, <em>, etc.)
+        r.querySelectorAll('[data-i18n-html]').forEach(function (el) {
+            const key = el.getAttribute('data-i18n-html');
+            if (key) el.innerHTML = t(key);
+        });
+        // title attr
+        r.querySelectorAll('[data-i18n-title]').forEach(function (el) {
+            const key = el.getAttribute('data-i18n-title');
+            if (key) el.setAttribute('title', t(key));
+        });
+        // placeholder attr
+        r.querySelectorAll('[data-i18n-placeholder]').forEach(function (el) {
+            const key = el.getAttribute('data-i18n-placeholder');
+            if (key) el.setAttribute('placeholder', t(key));
+        });
+        // <html lang="...">
+        if (document.documentElement) {
+            document.documentElement.setAttribute('lang', currentLang);
+        }
+    }
+
+    function setLang(lang) {
+        if (SUPPORTED_LANGS.indexOf(lang) === -1) lang = 'en';
+        if (lang === currentLang) return;
+        currentLang = lang;
+        try { localStorage.setItem(STORAGE_KEY, lang); } catch (_) { }
+        applyTranslations();
+        document.dispatchEvent(new CustomEvent('langchange', { detail: { lang: lang } }));
+    }
+
+    // Initialize as soon as DOM is parsed so static labels are correct on first paint.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            applyTranslations();
+            loadZoneTranslations();
+        });
+    } else {
+        applyTranslations();
+        loadZoneTranslations();
+    }
+
+    global.i18n = {
+        t: t,
+        pickItemName: pickItemName,
+        pickItemUrl: pickItemUrl,
+        pickSeasonName: pickSeasonName,
+        pickHeroName: pickHeroName,
+        tZone: tZone,
+        setLang: setLang,
+        getLang: getLang,
+        applyTranslations: applyTranslations,
+        loadZoneTranslations: loadZoneTranslations,
+        SUPPORTED_LANGS: SUPPORTED_LANGS,
+    };
+    // Convenience globals (kept short for inline usage)
+    global.t = t;
+    global.tZone = tZone;
+    global.pickItemName = pickItemName;
+    global.pickItemUrl = pickItemUrl;
+    global.pickSeasonName = pickSeasonName;
+    global.pickHeroName = pickHeroName;
+})(window);

--- a/src/titrack/web/static/index.html
+++ b/src/titrack/web/static/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <script src="i18n.js"></script>
 </head>
 <body>
     <div class="container">
@@ -18,59 +19,59 @@
                     <span id="player-details" class="player-details"></span>
                 </div>
                 <div id="awaiting-player-message" class="awaiting-message hidden">
-                    <span id="awaiting-player-summary">Waiting for character detection... (log in or sort your inventory)</span>
-                    <button type="button" class="awaiting-link" onclick="showNoCharacterModal()">See details</button>
+                    <span id="awaiting-player-summary" data-i18n="header.awaiting_player">Waiting for character detection... (log in or sort your inventory)</span>
+                    <button type="button" class="awaiting-link" onclick="showNoCharacterModal()" data-i18n="header.see_details">See details</button>
                 </div>
             </div>
             <div class="header-stats">
                 <div class="stat-card primary">
-                    <span class="stat-label">Net Worth</span>
+                    <span class="stat-label" data-i18n="header.net_worth">Net Worth</span>
                     <span id="net-worth" class="stat-value">0</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">Cumulative Value</span>
+                    <span class="stat-label" data-i18n="header.cumulative_value">Cumulative Value</span>
                     <span id="cumulative-value" class="stat-value">0</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">FE/Hour <span class="info-icon" title="Calculated from active run time only. Time spent in town, hideout, or between runs is not counted. This measures your farming efficiency, not total session time.">ⓘ</span></span>
+                    <span class="stat-label"><span data-i18n="header.fe_per_hour">FE/Hour</span> <span class="info-icon" data-i18n-title="header.fe_per_hour_tooltip" title="Calculated from active run time only. Time spent in town, hideout, or between runs is not counted. This measures your farming efficiency, not total session time.">ⓘ</span></span>
                     <span id="value-per-hour" class="stat-value">0</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">FE/Map</span>
+                    <span class="stat-label" data-i18n="header.fe_per_map">FE/Map</span>
                     <span id="value-per-map" class="stat-value">0</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">Runs</span>
+                    <span class="stat-label" data-i18n="header.runs">Runs</span>
                     <span id="total-runs" class="stat-value">0</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">Avg Run Time</span>
+                    <span class="stat-label" data-i18n="header.avg_run_time">Avg Run Time</span>
                     <span id="avg-run-time" class="stat-value">--</span>
                 </div>
                 <div class="stat-card">
-                    <span class="stat-label">Total Time</span>
+                    <span class="stat-label" data-i18n="header.total_time">Total Time</span>
                     <span class="total-time-row">
                         <span id="total-time" class="stat-value">--</span>
-                        <button id="pause-btn" class="pause-btn hidden" onclick="togglePause()" title="Pause tracking">⏸</button>
+                        <button id="pause-btn" class="pause-btn hidden" onclick="togglePause()" data-i18n-title="header.pause_tracking" title="Pause tracking">⏸</button>
                     </span>
                 </div>
             </div>
             <div class="header-controls">
-                <button id="overlay-btn" class="overlay-btn hidden" onclick="launchOverlay()" title="Open mini overlay">Overlay</button>
-                <button class="economy-btn" onclick="openEconomy()" title="Open titrack.ninja economy data">Economy</button>
+                <button id="overlay-btn" class="overlay-btn hidden" onclick="launchOverlay()" data-i18n="controls.overlay" data-i18n-title="controls.overlay_tooltip" title="Open mini overlay">Overlay</button>
+                <button class="economy-btn" onclick="openEconomy()" data-i18n="controls.economy" data-i18n-title="controls.economy_tooltip" title="Open titrack.ninja economy data">Economy</button>
                 <div class="cloud-sync-control">
                     <label class="toggle cloud-toggle">
                         <input type="checkbox" id="cloud-sync-toggle">
-                        <span>Cloud Sync</span>
+                        <span data-i18n="controls.cloud_sync">Cloud Sync</span>
                     </label>
-                    <span id="cloud-sync-status" class="cloud-status-indicator" title="Cloud sync status"></span>
+                    <span id="cloud-sync-status" class="cloud-status-indicator" data-i18n-title="controls.cloud_sync_tooltip" title="Cloud sync status"></span>
                 </div>
-                <button class="settings-btn" onclick="openSettingsModal()" title="Settings">&#9881;</button>
-                <button class="help-btn" onclick="openHelpModal()">Instructions</button>
-                <button id="reset-stats-btn" class="reset-btn" onclick="resetStats()">Reset Stats</button>
+                <button class="settings-btn" onclick="openSettingsModal()" data-i18n-title="controls.settings" title="Settings">&#9881;</button>
+                <button class="help-btn" onclick="openHelpModal()" data-i18n="controls.instructions">Instructions</button>
+                <button id="reset-stats-btn" class="reset-btn" onclick="resetStats()" data-i18n="controls.reset_stats">Reset Stats</button>
                 <label class="toggle">
                     <input type="checkbox" id="auto-refresh" checked>
-                    <span>Auto-refresh</span>
+                    <span data-i18n="controls.auto_refresh">Auto-refresh</span>
                 </label>
                 <span id="status-indicator" class="status-dot"></span>
             </div>
@@ -78,11 +79,11 @@
 
         <section class="charts-row">
             <div class="chart-panel">
-                <h2>Cumulative Value</h2>
+                <h2 data-i18n="charts.cumulative_value">Cumulative Value</h2>
                 <canvas id="cumulative-value-chart"></canvas>
             </div>
             <div class="chart-panel">
-                <h2>FE / Hour <span class="info-icon" title="Calculated from active run time only. Time spent in town, hideout, or between runs is not counted. This measures your farming efficiency, not total session time.">ⓘ</span></h2>
+                <h2><span data-i18n="charts.fe_per_hour">FE / Hour</span> <span class="info-icon" data-i18n-title="header.fe_per_hour_tooltip" title="Calculated from active run time only. Time spent in town, hideout, or between runs is not counted. This measures your farming efficiency, not total session time.">ⓘ</span></h2>
                 <canvas id="value-rate-chart"></canvas>
             </div>
         </section>
@@ -92,11 +93,11 @@
                 <section id="active-run-panel" class="panel active-run-panel hidden">
                     <h2>
                         <span class="active-indicator"></span>
-                        Current Run: <span id="active-run-zone">--</span>
+                        <span data-i18n="active_run.title_prefix">Current Run:</span> <span id="active-run-zone">--</span>
                         <span id="active-run-duration" class="active-run-duration">--</span>
                     </h2>
                     <div class="active-run-stats">
-                        <span class="active-run-value">Value: <strong id="active-run-value">0</strong> FE</span>
+                        <span class="active-run-value"><span data-i18n="active_run.value">Value:</span> <strong id="active-run-value">0</strong> <span data-i18n="unit.fe">FE</span></span>
                     </div>
                     <div id="active-run-loot" class="active-run-loot">
                         <!-- Live drops will appear here -->
@@ -105,21 +106,21 @@
 
                 <section class="panel">
                     <div class="section-header">
-                        <h2>Recent Runs</h2>
-                        <button class="report-btn" onclick="showLootReport()">Report</button>
+                        <h2 data-i18n="runs.title">Recent Runs</h2>
+                        <button class="report-btn" onclick="showLootReport()" data-i18n="runs.report">Report</button>
                     </div>
                 <div class="runs-scroll-container">
                 <table id="runs-table">
                     <thead>
                         <tr>
-                            <th>Zone</th>
-                            <th>Duration</th>
-                            <th>Value</th>
+                            <th data-i18n="runs.col_zone">Zone</th>
+                            <th data-i18n="runs.col_duration">Duration</th>
+                            <th data-i18n="runs.col_value">Value</th>
                             <th></th>
                         </tr>
                     </thead>
                     <tbody id="runs-body">
-                        <tr><td colspan="4" class="loading">Loading...</td></tr>
+                        <tr><td colspan="4" class="loading" data-i18n="runs.loading">Loading...</td></tr>
                     </tbody>
                 </table>
                 </div>
@@ -127,36 +128,36 @@
             </div>
 
             <section class="panel">
-                <h2>Current Inventory
-                    <button class="hide-items-btn" id="hide-items-btn" onclick="openHideItemsModal()">Hide Items</button>
+                <h2><span data-i18n="inventory.title">Current Inventory</span>
+                    <button class="hide-items-btn" id="hide-items-btn" onclick="openHideItemsModal()" data-i18n="inventory.hide_items">Hide Items</button>
                     <span class="inv-filter-wrap">
-                        <button class="inv-filter-btn" id="inv-filter-btn" onclick="toggleInvFilterMenu()" title="Filter by tab">
+                        <button class="inv-filter-btn" id="inv-filter-btn" onclick="toggleInvFilterMenu()" data-i18n-title="inventory.filter_tooltip" title="Filter by tab">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                         </button>
                         <div class="inv-filter-menu hidden" id="inv-filter-menu">
-                            <button class="inv-filter-option active" data-tab="" onclick="filterInventoryTab(this)">All</button>
-                            <button class="inv-filter-option" data-tab="100" onclick="filterInventoryTab(this)">Gear</button>
-                            <button class="inv-filter-option" data-tab="101" onclick="filterInventoryTab(this)">Skill</button>
-                            <button class="inv-filter-option" data-tab="102" onclick="filterInventoryTab(this)">Commodity</button>
-                            <button class="inv-filter-option" data-tab="103" onclick="filterInventoryTab(this)">Others</button>
+                            <button class="inv-filter-option active" data-tab="" onclick="filterInventoryTab(this)" data-i18n="inventory.tab_all">All</button>
+                            <button class="inv-filter-option" data-tab="100" onclick="filterInventoryTab(this)" data-i18n="inventory.tab_gear">Gear</button>
+                            <button class="inv-filter-option" data-tab="101" onclick="filterInventoryTab(this)" data-i18n="inventory.tab_skill">Skill</button>
+                            <button class="inv-filter-option" data-tab="102" onclick="filterInventoryTab(this)" data-i18n="inventory.tab_commodity">Commodity</button>
+                            <button class="inv-filter-option" data-tab="103" onclick="filterInventoryTab(this)" data-i18n="inventory.tab_others">Others</button>
                         </div>
                     </span>
                 </h2>
                 <table id="inventory-table">
                     <thead>
                         <tr>
-                            <th>Item</th>
+                            <th data-i18n="inventory.col_item">Item</th>
                             <th class="sortable" data-sort="quantity" onclick="sortInventory('quantity')">
-                                Qty <span class="sort-indicator" id="sort-quantity"></span>
+                                <span data-i18n="inventory.col_qty">Qty</span> <span class="sort-indicator" id="sort-quantity"></span>
                             </th>
                             <th class="sortable active" data-sort="value" onclick="sortInventory('value')">
-                                Value <span class="sort-indicator" id="sort-value"></span>
+                                <span data-i18n="inventory.col_value">Value</span> <span class="sort-indicator" id="sort-value"></span>
                             </th>
-                            <th id="sparkline-header" class="sparkline-header hidden" title="Price trend (72h)">Trend</th>
+                            <th id="sparkline-header" class="sparkline-header hidden" data-i18n="inventory.col_trend" data-i18n-title="inventory.trend_tooltip" title="Price trend (72h)">Trend</th>
                         </tr>
                     </thead>
                     <tbody id="inventory-body">
-                        <tr><td colspan="4" class="loading">Loading...</td></tr>
+                        <tr><td colspan="4" class="loading" data-i18n="runs.loading">Loading...</td></tr>
                     </tbody>
                 </table>
             </section>
@@ -167,17 +168,17 @@
             <span id="collector-status">Collector: --</span>
             <span class="footer-version">
                 <span id="app-version">v--</span>
-                <a href="https://discord.gg/39W7YEywe5" target="_blank" class="discord-link" title="Join the TITrack Discord">
+                <a href="https://discord.gg/39W7YEywe5" target="_blank" class="discord-link" data-i18n-title="footer.discord_tooltip" title="Join the TITrack Discord">
                     <svg width="16" height="12" viewBox="0 0 127.14 96.36" fill="currentColor"><path d="M107.7 8.07A105.15 105.15 0 0 0 81.47 0a72.06 72.06 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.37 72.37 0 0 0 45.64 0 105.89 105.89 0 0 0 19.39 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.42 68.42 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2.03a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2.03a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.25 105.25 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15ZM42.45 65.69C36.18 65.69 31 60 31 53.05s5-12.68 11.45-12.68S54 46.07 53.89 53.05 48.84 65.69 42.45 65.69Zm42.24 0C78.41 65.69 73.25 60 73.25 53.05s5-12.68 11.44-12.68S96.23 46.07 96.12 53.05 91.08 65.69 84.69 65.69Z"/></svg>
                     Discord
                 </a>
-                <a href="https://ko-fi.com/titrack" target="_blank" class="kofi-link" title="Help cover server costs">
+                <a href="https://ko-fi.com/titrack" target="_blank" class="kofi-link" data-i18n-title="footer.kofi_tooltip" title="Help cover server costs">
                     <svg width="16" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.776-4.011 3.776s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.511zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z"/></svg>
-                    Help cover server costs
+                    <span data-i18n="footer.kofi">Help cover server costs</span>
                 </a>
-                <button id="check-updates-btn" class="update-btn" onclick="checkForUpdates()">Check for Updates</button>
-                <span id="update-badge" class="update-badge hidden" title="Update available"></span>
-                <button id="exit-app-btn" class="exit-btn hidden" onclick="exitApp()">Exit App</button>
+                <button id="check-updates-btn" class="update-btn" onclick="checkForUpdates()" data-i18n="footer.check_updates">Check for Updates</button>
+                <span id="update-badge" class="update-badge hidden" data-i18n-title="footer.update_tooltip" title="Update available"></span>
+                <button id="exit-app-btn" class="exit-btn hidden" onclick="exitApp()" data-i18n="footer.exit">Exit App</button>
             </span>
         </footer>
     </div>
@@ -185,7 +186,7 @@
     <div id="loot-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 id="modal-title">Run Details</h3>
+                <h3 id="modal-title" data-i18n="modal.run_details">Run Details</h3>
                 <button class="close-btn" onclick="closeModal()">&times;</button>
             </div>
             <div id="modal-body"></div>
@@ -195,80 +196,80 @@
     <div id="help-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h3>How to Use TITrack</h3>
+                <h3 data-i18n="help.title">How to Use TITrack</h3>
                 <button class="close-btn" onclick="closeHelpModal()">&times;</button>
             </div>
             <div class="help-body">
                 <section class="help-section">
-                    <h4>1. Enable Game Logging</h4>
-                    <p>TITrack reads the game's log file to track your loot. To enable logging:</p>
+                    <h4 data-i18n="help.s1.title">1. Enable Game Logging</h4>
+                    <p data-i18n="help.s1.intro">TITrack reads the game's log file to track your loot. To enable logging:</p>
                     <ol>
-                        <li>Open Torchlight Infinite</li>
-                        <li>Go to <strong>Settings</strong></li>
-                        <li>Find and click the <strong>"Enable Log"</strong> button</li>
+                        <li data-i18n-html="help.s1.step1">Open Torchlight Infinite</li>
+                        <li data-i18n-html="help.s1.step2">Go to <strong>Settings</strong></li>
+                        <li data-i18n-html="help.s1.step3">Find and click the <strong>"Enable Log"</strong> button</li>
                     </ol>
-                    <p class="help-note">Without this enabled, TITrack cannot capture any data.</p>
+                    <p class="help-note" data-i18n="help.s1.note">Without this enabled, TITrack cannot capture any data.</p>
                 </section>
 
                 <section class="help-section">
-                    <h4>2. Character Detection</h4>
-                    <p>TITrack automatically detects your character from the game log:</p>
+                    <h4 data-i18n="help.s2.title">2. Character Detection</h4>
+                    <p data-i18n="help.s2.intro">TITrack automatically detects your character from the game log:</p>
                     <ul>
-                        <li>If you've played before with logging enabled, your character is detected <strong>automatically</strong> on startup</li>
-                        <li>If this is your first time, log in with your character and TITrack will detect it</li>
-                        <li>To switch characters, just log out and back in (do NOT close the game)</li>
+                        <li data-i18n-html="help.s2.b1">If you've played before with logging enabled, your character is detected <strong>automatically</strong> on startup</li>
+                        <li data-i18n-html="help.s2.b2">If this is your first time, log in with your character and TITrack will detect it</li>
+                        <li data-i18n-html="help.s2.b3">To switch characters, just log out and back in (do NOT close the game)</li>
                     </ul>
-                    <p class="help-note">TITrack tracks data separately for each character and league.</p>
+                    <p class="help-note" data-i18n="help.s2.note">TITrack tracks data separately for each character and league.</p>
                 </section>
 
                 <section class="help-section">
-                    <h4>3. Sync Your Inventory</h4>
-                    <p>To populate the inventory display with your current items:</p>
+                    <h4 data-i18n="help.s3.title">3. Sync Your Inventory</h4>
+                    <p data-i18n="help.s3.intro">To populate the inventory display with your current items:</p>
                     <ol>
-                        <li>Open your inventory in-game</li>
-                        <li>Click the <strong>Sort</strong> button (auto-arranges items)</li>
-                        <li>Repeat for each tab you want to track (Skill, Commodity, Others)</li>
+                        <li data-i18n-html="help.s3.step1">Open your inventory in-game</li>
+                        <li data-i18n-html="help.s3.step2">Click the <strong>Sort</strong> button (auto-arranges items)</li>
+                        <li data-i18n-html="help.s3.step3">Repeat for each tab you want to track (Skill, Commodity, Others)</li>
                     </ol>
-                    <p class="help-note">The Gear tab is not tracked because gear prices depend heavily on specific affixes.</p>
+                    <p class="help-note" data-i18n="help.s3.note">The Gear tab is not tracked because gear prices depend heavily on specific affixes.</p>
                 </section>
 
                 <section class="help-section">
-                    <h4>4. Automatic Price Learning</h4>
-                    <p>TITrack learns item prices automatically when you use the in-game Exchange:</p>
+                    <h4 data-i18n="help.s4.title">4. Automatic Price Learning</h4>
+                    <p data-i18n="help.s4.intro">TITrack learns item prices automatically when you use the in-game Exchange:</p>
                     <ol>
-                        <li>Open the Exchange in-game</li>
-                        <li>Search for any item you want to price</li>
-                        <li>TITrack captures the listed prices and calculates a reference price (10th percentile)</li>
+                        <li data-i18n-html="help.s4.step1">Open the Exchange in-game</li>
+                        <li data-i18n-html="help.s4.step2">Search for any item you want to price</li>
+                        <li data-i18n-html="help.s4.step3">TITrack captures the listed prices and calculates a reference price (10th percentile)</li>
                     </ol>
-                    <p class="help-note">Prices are saved locally and used to calculate your loot value and net worth.</p>
+                    <p class="help-note" data-i18n="help.s4.note">Prices are saved locally and used to calculate your loot value and net worth.</p>
                 </section>
 
                 <section class="help-section">
-                    <h4>5. Tracking Runs</h4>
-                    <p>Once logging is enabled, TITrack automatically:</p>
+                    <h4 data-i18n="help.s5.title">5. Tracking Runs</h4>
+                    <p data-i18n="help.s5.intro">Once logging is enabled, TITrack automatically:</p>
                     <ul>
-                        <li>Detects when you enter and leave maps</li>
-                        <li>Tracks all items picked up during each run</li>
-                        <li>Calculates value based on learned prices</li>
-                        <li>Shows your FE/Hour based on active run time only</li>
+                        <li data-i18n-html="help.s5.b1">Detects when you enter and leave maps</li>
+                        <li data-i18n-html="help.s5.b2">Tracks all items picked up during each run</li>
+                        <li data-i18n-html="help.s5.b3">Calculates value based on learned prices</li>
+                        <li data-i18n-html="help.s5.b4">Shows your FE/Hour based on active run time only</li>
                     </ul>
                 </section>
 
                 <section class="help-section">
-                    <h4>6. Cloud Sync (Optional)</h4>
-                    <p>Share and receive community pricing data by enabling Cloud Sync:</p>
+                    <h4 data-i18n="help.s6.title">6. Cloud Sync (Optional)</h4>
+                    <p data-i18n="help.s6.intro">Share and receive community pricing data by enabling Cloud Sync:</p>
                     <ol>
-                        <li>Click the <strong>Cloud Sync</strong> toggle in the header</li>
-                        <li>When enabled, your Exchange searches are anonymously shared</li>
-                        <li>You'll receive aggregated prices from other users</li>
+                        <li data-i18n-html="help.s6.step1">Click the <strong>Cloud Sync</strong> toggle in the header</li>
+                        <li data-i18n-html="help.s6.step2">When enabled, your Exchange searches are anonymously shared</li>
+                        <li data-i18n-html="help.s6.step3">You'll receive aggregated prices from other users</li>
                     </ol>
-                    <p>Benefits:</p>
+                    <p data-i18n="help.s6.benefits">Benefits:</p>
                     <ul>
-                        <li>Get prices for items you haven't searched yet</li>
-                        <li>See price trends with sparkline charts</li>
-                        <li>Help the community by contributing your data</li>
+                        <li data-i18n-html="help.s6.b1">Get prices for items you haven't searched yet</li>
+                        <li data-i18n-html="help.s6.b2">See price trends with sparkline charts</li>
+                        <li data-i18n-html="help.s6.b3">Help the community by contributing your data</li>
                     </ul>
-                    <p class="help-note">Cloud Sync is completely optional and anonymous. No account required. Only Exchange prices are shared, never manual edits. Data requires 3+ contributors before being shown.</p>
+                    <p class="help-note" data-i18n="help.s6.note">Cloud Sync is completely optional and anonymous. No account required. Only Exchange prices are shared, never manual edits. Data requires 3+ contributors before being shown.</p>
                 </section>
             </div>
         </div>
@@ -277,54 +278,54 @@
     <div id="no-character-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h3>Character Not Detected</h3>
+                <h3 data-i18n="nochar.title">Character Not Detected</h3>
                 <button class="close-btn" onclick="closeNoCharacterModal()">&times;</button>
             </div>
             <div class="help-body">
                 <section class="help-section">
                     <div id="no-character-diagnostic" class="awaiting-panel">
-                        <div class="awaiting-title">Diagnostics</div>
-                        <div id="no-character-diagnostic-body" class="awaiting-message-body">
+                        <div class="awaiting-title" data-i18n="nochar.diagnostics">Diagnostics</div>
+                        <div id="no-character-diagnostic-body" class="awaiting-message-body" data-i18n="nochar.checking">
                             Checking log activity...
                         </div>
                         <div id="no-character-diagnostic-actions" class="awaiting-actions hidden"></div>
                     </div>
                 </section>
                 <section class="help-section">
-                    <h4>How character detection works</h4>
-                    <p>TITrack reads your character name and season from the game log, but Torchlight only writes those details when its <strong>Enable Log</strong> setting is on <em>at the exact moment</em> the game's login-time data packet arrives. Enabling the log after you're already logged in is not enough — you need to trigger a new login while the log is on.</p>
+                    <h4 data-i18n="nochar.detect_title">How character detection works</h4>
+                    <p data-i18n-html="nochar.detect_intro">TITrack reads your character name and season from the game log, but Torchlight only writes those details when its <strong>Enable Log</strong> setting is on <em>at the exact moment</em> the game's login-time data packet arrives. Enabling the log after you're already logged in is not enough — you need to trigger a new login while the log is on.</p>
                 </section>
                 <section class="help-section">
-                    <h4>Try this first</h4>
+                    <h4 data-i18n="nochar.try_title">Try this first</h4>
                     <ol>
-                        <li>Open Torchlight Infinite and log in to your character as usual.</li>
-                        <li>Open the in-game <strong>Settings</strong> menu and turn on <strong>Enable Log</strong>.</li>
-                        <li>Exit all the way back to the <strong>Select Character</strong> screen (you don't need to quit the client).</li>
-                        <li>Click your character to log back in.</li>
+                        <li data-i18n-html="nochar.try_step1">Open Torchlight Infinite and log in to your character as usual.</li>
+                        <li data-i18n-html="nochar.try_step2">Open the in-game <strong>Settings</strong> menu and turn on <strong>Enable Log</strong>.</li>
+                        <li data-i18n-html="nochar.try_step3">Exit all the way back to the <strong>Select Character</strong> screen (you don't need to quit the client).</li>
+                        <li data-i18n-html="nochar.try_step4">Click your character to log back in.</li>
                     </ol>
-                    <p class="help-note">This works because the server re-sends your full character data on every login, and Torchlight only writes it to the log when Enable Log is already on when that packet arrives.</p>
+                    <p class="help-note" data-i18n="nochar.try_note">This works because the server re-sends your full character data on every login, and Torchlight only writes it to the log when Enable Log is already on when that packet arrives.</p>
                 </section>
                 <section class="help-section">
-                    <h4>If that didn't work</h4>
-                    <p>On some sessions the game records only a truncated placeholder (<code>+player+...</code>) for your character even with logging on. Resetting the client usually clears this:</p>
+                    <h4 data-i18n="nochar.fail_title">If that didn't work</h4>
+                    <p data-i18n-html="nochar.fail_intro">On some sessions the game records only a truncated placeholder (<code>+player+...</code>) for your character even with logging on. Resetting the client usually clears this:</p>
                     <ol>
-                        <li>Fully close Torchlight Infinite (quit to desktop — not just log out).</li>
-                        <li>Reopen the client and log in to your character.</li>
-                        <li>Open <strong>Settings</strong> and turn on <strong>Enable Log</strong>.</li>
-                        <li>Exit to <strong>Select Character</strong> and log back in.</li>
+                        <li data-i18n-html="nochar.fail_step1">Fully close Torchlight Infinite (quit to desktop — not just log out).</li>
+                        <li data-i18n-html="nochar.fail_step2">Reopen the client and log in to your character.</li>
+                        <li data-i18n-html="nochar.fail_step3">Open <strong>Settings</strong> and turn on <strong>Enable Log</strong>.</li>
+                        <li data-i18n-html="nochar.fail_step4">Exit to <strong>Select Character</strong> and log back in.</li>
                     </ol>
-                    <p class="help-note">A sort of your inventory (click the Sort button in your bag) also forces a fresh inventory dump, which is a useful extra nudge if detection still doesn't fire.</p>
+                    <p class="help-note" data-i18n="nochar.fail_note">A sort of your inventory (click the Sort button in your bag) also forces a fresh inventory dump, which is a useful extra nudge if detection still doesn't fire.</p>
                 </section>
                 <section class="help-section">
-                    <h4>Other things to check</h4>
+                    <h4 data-i18n="nochar.other_title">Other things to check</h4>
                     <ul>
-                        <li><strong>Wrong log file.</strong> If you have both the Steam and standalone Torchlight client installed, TITrack may be watching the log for the client you aren't currently playing on. The diagnostic above will suggest a switch when it detects a newer log elsewhere.</li>
-                        <li><strong>Game closed.</strong> Torchlight only writes to its log while it's running. If you quit the game, the log stops updating and TITrack will flag it as stale.</li>
-                        <li><strong>Enable Log doesn't persist.</strong> Torchlight resets this toggle to off every time the client restarts. You need to turn it back on each session.</li>
+                        <li data-i18n-html="nochar.other_b1"><strong>Wrong log file.</strong> If you have both the Steam and standalone Torchlight client installed, TITrack may be watching the log for the client you aren't currently playing on. The diagnostic above will suggest a switch when it detects a newer log elsewhere.</li>
+                        <li data-i18n-html="nochar.other_b2"><strong>Game closed.</strong> Torchlight only writes to its log while it's running. If you quit the game, the log stops updating and TITrack will flag it as stale.</li>
+                        <li data-i18n-html="nochar.other_b3"><strong>Enable Log doesn't persist.</strong> Torchlight resets this toggle to off every time the client restarts. You need to turn it back on each session.</li>
                     </ul>
                 </section>
                 <div class="modal-actions">
-                    <button onclick="closeNoCharacterModal()" class="dismiss-btn">Dismiss</button>
+                    <button onclick="closeNoCharacterModal()" class="dismiss-btn" data-i18n="nochar.dismiss">Dismiss</button>
                 </div>
             </div>
         </div>
@@ -333,102 +334,117 @@
     <div id="settings-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h3>Settings</h3>
+                <h3 data-i18n="settings.title">Settings</h3>
                 <button class="close-btn" onclick="closeSettingsModal()">&times;</button>
             </div>
             <div class="settings-body">
+                <!-- Language Section -->
+                <section class="settings-section">
+                    <h4 data-i18n="settings.section_language">Language</h4>
+                    <label class="settings-toggle">
+                        <select id="settings-language" class="settings-select">
+                            <option value="en">English</option>
+                            <option value="zh-CN">简体中文</option>
+                        </select>
+                        <div class="toggle-info">
+                            <span class="toggle-label" data-i18n="settings.language_label">Language</span>
+                            <span class="toggle-desc" data-i18n="settings.language_desc">Display language for the dashboard and overlay</span>
+                        </div>
+                    </label>
+                </section>
+
                 <!-- Value Calculations Section -->
                 <section class="settings-section">
-                    <h4>Value Calculations</h4>
+                    <h4 data-i18n="settings.section_value">Value Calculations</h4>
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-trade-tax">
                         <div class="toggle-info">
-                            <span class="toggle-label">Trade Tax</span>
-                            <span class="toggle-desc">Apply 12.5% trade house tax to item values</span>
+                            <span class="toggle-label" data-i18n="settings.trade_tax">Trade Tax</span>
+                            <span class="toggle-desc" data-i18n="settings.trade_tax_desc">Apply 12.5% trade house tax to item values</span>
                         </div>
                     </label>
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-map-costs">
                         <div class="toggle-info">
-                            <span class="toggle-label">Map Costs</span>
-                            <span class="toggle-desc">Track and subtract compass/beacon costs from run values</span>
+                            <span class="toggle-label" data-i18n="settings.map_costs">Map Costs</span>
+                            <span class="toggle-desc" data-i18n="settings.map_costs_desc">Track and subtract compass/beacon costs from run values</span>
                         </div>
                     </label>
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-realtime-tracking">
                         <div class="toggle-info">
-                            <span class="toggle-label">Real-Time Tracking</span>
-                            <span class="toggle-desc">Use wall-clock time for FE/Hour and Total Time instead of in-map time only</span>
+                            <span class="toggle-label" data-i18n="settings.realtime">Real-Time Tracking</span>
+                            <span class="toggle-desc" data-i18n="settings.realtime_desc">Use wall-clock time for FE/Hour and Total Time instead of in-map time only</span>
                         </div>
                     </label>
                 </section>
 
                 <!-- Overlay Section -->
                 <section class="settings-section">
-                    <h4>Overlay</h4>
+                    <h4 data-i18n="settings.section_overlay">Overlay</h4>
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-overlay-hide-loot">
                         <div class="toggle-info">
-                            <span class="toggle-label">Hide Loot Pickups</span>
-                            <span class="toggle-desc">Hide the loot section in the overlay for a more compact view (stats only)</span>
+                            <span class="toggle-label" data-i18n="settings.overlay_hide_loot">Hide Loot Pickups</span>
+                            <span class="toggle-desc" data-i18n="settings.overlay_hide_loot_desc">Hide the loot section in the overlay for a more compact view (stats only)</span>
                         </div>
                     </label>
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-overlay-micro-mode">
                         <div class="toggle-info">
-                            <span class="toggle-label">Micro Overlay</span>
-                            <span class="toggle-desc">Show a compact overlay with only key stats instead of the full overlay</span>
+                            <span class="toggle-label" data-i18n="settings.overlay_micro">Micro Overlay</span>
+                            <span class="toggle-desc" data-i18n="settings.overlay_micro_desc">Show a compact overlay with only key stats instead of the full overlay</span>
                         </div>
                     </label>
                     <div id="micro-stats-picker" class="micro-stats-picker hidden">
                         <div class="micro-orientation-row">
-                            <span class="micro-stats-label">Layout:</span>
+                            <span class="micro-stats-label" data-i18n="settings.layout">Layout:</span>
                             <div class="micro-orientation-buttons">
-                                <button class="micro-orientation-btn active" id="micro-orient-horizontal" onclick="setMicroOrientation('horizontal')">Horizontal</button>
-                                <button class="micro-orientation-btn" id="micro-orient-vertical" onclick="setMicroOrientation('vertical')">Vertical</button>
+                                <button class="micro-orientation-btn active" id="micro-orient-horizontal" onclick="setMicroOrientation('horizontal')" data-i18n="settings.layout_horizontal">Horizontal</button>
+                                <button class="micro-orientation-btn" id="micro-orient-vertical" onclick="setMicroOrientation('vertical')" data-i18n="settings.layout_vertical">Vertical</button>
                             </div>
                         </div>
                         <div class="micro-font-scale-row">
-                            <span class="micro-stats-label">Font size:</span>
+                            <span class="micro-stats-label" data-i18n="settings.font_size">Font size:</span>
                             <input type="range" id="micro-font-scale-slider" min="70" max="160" value="100" step="10">
                             <span id="micro-font-scale-value">100%</span>
                         </div>
-                        <span class="micro-stats-label">Visible stats: <span class="micro-stats-hint">(drag to reorder)</span></span>
+                        <span class="micro-stats-label"><span data-i18n="settings.visible_stats">Visible stats:</span> <span class="micro-stats-hint" data-i18n="settings.drag_to_reorder">(drag to reorder)</span></span>
                         <div id="micro-stats-chips" class="micro-stats-chips"></div>
                     </div>
                 </section>
 
                 <!-- Low Supply Alerts Section -->
                 <section class="settings-section">
-                    <h4>Low Supply Alerts</h4>
-                    <p class="settings-desc">Get notified when map supplies drop to a threshold. Set to 0 to disable.</p>
+                    <h4 data-i18n="settings.section_supply">Low Supply Alerts</h4>
+                    <p class="settings-desc" data-i18n="settings.supply_desc">Get notified when map supplies drop to a threshold. Set to 0 to disable.</p>
                     <div class="supply-threshold-row">
-                        <label for="settings-supply-beacon">Beacons</label>
+                        <label for="settings-supply-beacon" data-i18n="settings.supply_beacons">Beacons</label>
                         <input type="number" id="settings-supply-beacon" class="supply-threshold-input" min="0" step="1" value="0">
                     </div>
                     <div class="supply-threshold-row">
-                        <label for="settings-supply-compass">Compasses</label>
+                        <label for="settings-supply-compass" data-i18n="settings.supply_compasses">Compasses</label>
                         <input type="number" id="settings-supply-compass" class="supply-threshold-input" min="0" step="1" value="0">
                     </div>
                     <div class="supply-threshold-row">
-                        <label for="settings-supply-resonance">Resonance</label>
+                        <label for="settings-supply-resonance" data-i18n="settings.supply_resonance">Resonance</label>
                         <input type="number" id="settings-supply-resonance" class="supply-threshold-input" min="0" step="1" value="0">
                     </div>
                 </section>
 
                 <!-- Game Directory Section -->
                 <section class="settings-section">
-                    <h4>Game Directory</h4>
-                    <p id="settings-log-path-current">Current: <code id="current-log-path">Loading...</code></p>
+                    <h4 data-i18n="settings.section_game_dir">Game Directory</h4>
+                    <p id="settings-log-path-current"><span data-i18n="settings.current_path">Current:</span> <code id="current-log-path" data-i18n="settings.path_loading">Loading...</code></p>
                     <div class="log-path-input-group">
-                        <input type="text" id="log-directory-input" placeholder="C:\Torchlight Infinite or C:\...\Logs\UE_game.log" onkeyup="if(event.key === 'Enter') validateLogDirectory()">
-                        <button onclick="browseForGameFolder()" class="browse-btn" id="browse-folder-btn" style="display: none;">Browse</button>
-                        <button onclick="validateLogDirectory()" class="validate-btn">Validate</button>
+                        <input type="text" id="log-directory-input" data-i18n-placeholder="settings.path_placeholder" placeholder="C:\Torchlight Infinite or C:\...\Logs\UE_game.log" onkeyup="if(event.key === 'Enter') validateLogDirectory()">
+                        <button onclick="browseForGameFolder()" class="browse-btn" id="browse-folder-btn" style="display: none;" data-i18n="settings.browse">Browse</button>
+                        <button onclick="validateLogDirectory()" class="validate-btn" data-i18n="settings.validate">Validate</button>
                     </div>
                     <p id="log-path-status" class="log-path-status"></p>
-                    <p class="help-note">You can enter the game folder, the Logs folder, or the full path to UE_game.log</p>
+                    <p class="help-note" data-i18n="settings.path_help">You can enter the game folder, the Logs folder, or the full path to UE_game.log</p>
                     <div class="settings-section-actions">
-                        <button onclick="saveLogDirectory()" id="save-log-dir-btn" class="settings-btn-primary" disabled>Save & Restart</button>
+                        <button onclick="saveLogDirectory()" id="save-log-dir-btn" class="settings-btn-primary" disabled data-i18n="settings.save_restart">Save & Restart</button>
                     </div>
                 </section>
             </div>
@@ -438,41 +454,41 @@
     <div id="loot-report-modal" class="modal hidden">
         <div class="modal-content modal-wide">
             <div class="modal-header">
-                <h3>Loot Report</h3>
+                <h3 data-i18n="report.title">Loot Report</h3>
                 <button class="close-btn" onclick="closeLootReportModal()">&times;</button>
             </div>
             <div id="loot-report-body">
                 <div class="report-summary">
                     <div class="report-stat">
-                        <span class="report-stat-label">Gross Value</span>
+                        <span class="report-stat-label" data-i18n="report.gross">Gross Value</span>
                         <span id="report-total-value" class="report-stat-value">--</span>
                     </div>
                     <div id="report-cost-stat" class="report-stat hidden">
-                        <span class="report-stat-label">Map Costs</span>
+                        <span class="report-stat-label" data-i18n="report.map_costs">Map Costs</span>
                         <span id="report-map-costs" class="report-stat-value negative">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Profit</span>
+                        <span class="report-stat-label" data-i18n="report.profit">Profit</span>
                         <span id="report-profit" class="report-stat-value primary">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Runs</span>
+                        <span class="report-stat-label" data-i18n="report.runs">Runs</span>
                         <span id="report-run-count" class="report-stat-value">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Total Time</span>
+                        <span class="report-stat-label" data-i18n="report.total_time">Total Time</span>
                         <span id="report-total-time" class="report-stat-value">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Profit/Hour</span>
+                        <span class="report-stat-label" data-i18n="report.profit_per_hour">Profit/Hour</span>
                         <span id="report-profit-per-hour" class="report-stat-value">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Profit/Map</span>
+                        <span class="report-stat-label" data-i18n="report.profit_per_map">Profit/Map</span>
                         <span id="report-profit-per-map" class="report-stat-value">--</span>
                     </div>
                     <div class="report-stat">
-                        <span class="report-stat-label">Unique Items</span>
+                        <span class="report-stat-label" data-i18n="report.unique_items">Unique Items</span>
                         <span id="report-total-items" class="report-stat-value">--</span>
                     </div>
                 </div>
@@ -483,22 +499,22 @@
                     <table class="report-table">
                         <thead>
                             <tr>
-                                <th>Item</th>
-                                <th>Qty</th>
-                                <th>Unit Price</th>
-                                <th>Total Value</th>
-                                <th>%</th>
+                                <th data-i18n="report.col_item">Item</th>
+                                <th data-i18n="report.col_qty">Qty</th>
+                                <th data-i18n="report.col_unit_price">Unit Price</th>
+                                <th data-i18n="report.col_total_value">Total Value</th>
+                                <th data-i18n="report.col_pct">%</th>
                                 <th></th>
                             </tr>
                         </thead>
                         <tbody id="loot-report-table-body">
-                            <tr><td colspan="6" class="loading">Loading...</td></tr>
+                            <tr><td colspan="6" class="loading" data-i18n="runs.loading">Loading...</td></tr>
                         </tbody>
                     </table>
                 </div>
                 <div class="modal-actions">
-                    <button onclick="exportLootReportCSV()" class="export-btn">Export CSV</button>
-                    <button onclick="closeLootReportModal()" class="cancel-btn">Close</button>
+                    <button onclick="exportLootReportCSV()" class="export-btn" data-i18n="report.export_csv">Export CSV</button>
+                    <button onclick="closeLootReportModal()" class="cancel-btn" data-i18n="report.close">Close</button>
                 </div>
             </div>
         </div>
@@ -507,7 +523,7 @@
     <div id="update-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h3>Update Available</h3>
+                <h3 data-i18n="update.title">Update Available</h3>
                 <button class="close-btn" onclick="closeUpdateModal()">&times;</button>
             </div>
             <div class="update-body">
@@ -520,18 +536,18 @@
                 </div>
                 <div id="update-install-warning" class="update-install-warning hidden"></div>
                 <div class="update-release-notes">
-                    <h4>Release Notes</h4>
-                    <div id="update-release-notes" class="release-notes-content">Loading...</div>
+                    <h4 data-i18n="update.release_notes">Release Notes</h4>
+                    <div id="update-release-notes" class="release-notes-content" data-i18n="update.loading">Loading...</div>
                 </div>
                 <div class="update-progress hidden" id="update-progress-container">
                     <div class="progress-bar">
                         <div class="progress-fill" id="update-progress-bar" style="width: 0%"></div>
                     </div>
-                    <span class="progress-text" id="update-progress-text">Downloading...</span>
+                    <span class="progress-text" id="update-progress-text" data-i18n="footer.downloading">Downloading...</span>
                 </div>
                 <div class="modal-actions" id="update-actions">
-                    <button onclick="downloadAndInstallUpdate()" class="save-btn" id="update-download-btn">Download & Install</button>
-                    <button onclick="closeUpdateModal()" class="cancel-btn">Later</button>
+                    <button onclick="downloadAndInstallUpdate()" class="save-btn" id="update-download-btn" data-i18n="update.download_install">Download & Install</button>
+                    <button onclick="closeUpdateModal()" class="cancel-btn" data-i18n="update.later">Later</button>
                 </div>
             </div>
         </div>
@@ -540,29 +556,29 @@
     <div id="hide-items-modal" class="modal hidden">
         <div class="modal-content hide-items-modal-content">
             <div class="modal-header">
-                <h3>Hide Items from Inventory</h3>
+                <h3 data-i18n="hide.title">Hide Items from Inventory</h3>
                 <button class="close-btn" onclick="closeHideItemsModal()">&times;</button>
             </div>
             <div class="hide-items-body">
-                <p class="hide-items-hint" id="hide-items-hint-text">Check items to hide from inventory display. Hidden items still count toward net worth.</p>
+                <p class="hide-items-hint" id="hide-items-hint-text" data-i18n="hide.hint">Check items to hide from inventory display. Hidden items still count toward net worth.</p>
                 <div class="hide-items-worth-toggle">
                     <label class="settings-toggle">
                         <input type="checkbox" id="settings-hidden-exclude-worth">
                         <div class="toggle-info">
-                            <span class="toggle-label">Exclude from Net Worth</span>
-                            <span class="toggle-desc">Hidden items will not count toward net worth</span>
+                            <span class="toggle-label" data-i18n="hide.exclude_worth">Exclude from Net Worth</span>
+                            <span class="toggle-desc" data-i18n="hide.exclude_worth_desc">Hidden items will not count toward net worth</span>
                         </div>
                     </label>
                 </div>
-                <input type="text" id="hide-items-search" class="hide-items-search" placeholder="Search items..." oninput="renderHideItemsTable()">
+                <input type="text" id="hide-items-search" class="hide-items-search" data-i18n-placeholder="hide.search" placeholder="Search items..." oninput="renderHideItemsTable()">
                 <div class="hide-items-table-container">
                     <table class="hide-items-table">
                         <thead>
                             <tr>
                                 <th class="hide-col-check"></th>
-                                <th>Item</th>
-                                <th class="sortable" onclick="sortHideItemsTable('quantity')">Qty <span class="sort-indicator" id="hide-sort-quantity"></span></th>
-                                <th class="sortable active desc" onclick="sortHideItemsTable('value')">Value <span class="sort-indicator" id="hide-sort-value"></span></th>
+                                <th data-i18n="hide.col_item">Item</th>
+                                <th class="sortable" onclick="sortHideItemsTable('quantity')"><span data-i18n="hide.col_qty">Qty</span> <span class="sort-indicator" id="hide-sort-quantity"></span></th>
+                                <th class="sortable active desc" onclick="sortHideItemsTable('value')"><span data-i18n="hide.col_value">Value</span> <span class="sort-indicator" id="hide-sort-value"></span></th>
                             </tr>
                         </thead>
                         <tbody id="hide-items-body">
@@ -571,8 +587,8 @@
                 </div>
                 <div class="modal-actions">
                     <span class="hide-items-count" id="hide-items-count"></span>
-                    <button onclick="saveHideItems()" class="save-btn">Save</button>
-                    <button onclick="closeHideItemsModal()" class="cancel-btn">Cancel</button>
+                    <button onclick="saveHideItems()" class="save-btn" data-i18n="hide.save">Save</button>
+                    <button onclick="closeHideItemsModal()" class="cancel-btn" data-i18n="hide.cancel">Cancel</button>
                 </div>
             </div>
         </div>

--- a/src/titrack/web/static/style.css
+++ b/src/titrack/web/static/style.css
@@ -1570,6 +1570,23 @@ tr.nightmare .zone-name {
     flex-shrink: 0;
 }
 
+.settings-toggle .settings-select,
+.settings-select {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text, #e0e0e0);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 4px;
+    padding: 6px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.settings-select:hover {
+    border-color: var(--accent);
+}
+
 .toggle-info {
     display: flex;
     flex-direction: column;

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -724,3 +724,88 @@ class TestIconsEndpoint:
         response = client.get("/api/icons/999888")
         assert response.status_code == 404
         assert "No icon available" in response.json()["detail"]
+
+
+class TestI18nEndpoints:
+    """Internationalization-related API behaviour."""
+
+    def test_zone_translations_endpoint(self, client):
+        """/api/i18n/zones returns the zh-CN zone-name table."""
+        response = client.get("/api/i18n/zones")
+        assert response.status_code == 200
+        data = response.json()
+        assert "zh-CN" in data
+        # Must contain at least a few well-known zone translations
+        assert isinstance(data["zh-CN"], dict)
+        assert len(data["zh-CN"]) > 0
+
+    def test_inventory_returns_bilingual_names(self, db, repo):
+        """Inventory items expose name_en and name_cn (and legacy name)."""
+        from titrack.parser.patterns import FE_CONFIG_BASE_ID
+
+        now = datetime.now()
+        repo.upsert_item(Item(
+            config_base_id=FE_CONFIG_BASE_ID,
+            name_en="Flame Elementium",
+            name_cn="\u521d\u706b\u6e90\u8d28",
+            type_cn=None, icon_url=None, url_en=None, url_cn=None,
+        ))
+        repo.upsert_slot_state(SlotState(
+            page_id=102, slot_id=0, config_base_id=FE_CONFIG_BASE_ID,
+            num=42, updated_at=now,
+        ))
+
+        app = create_app(db, player_info=TEST_PLAYER_INFO)
+        client = TestClient(app)
+        response = client.get("/api/inventory")
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert len(items) == 1
+        item = items[0]
+        # Backwards-compat field still present
+        assert item["name"] == "Flame Elementium"
+        # New bilingual fields
+        assert item["name_en"] == "Flame Elementium"
+        assert item["name_cn"] == "\u521d\u706b\u6e90\u8d28"
+
+    def test_run_loot_returns_bilingual_names(self, seeded_db):
+        """Run details include name_en/name_cn for each loot item."""
+        app = create_app(seeded_db, player_info=TEST_PLAYER_INFO)
+        client = TestClient(app)
+        response = client.get("/api/runs/1")
+        assert response.status_code == 200
+        loot = response.json().get("loot", [])
+        assert len(loot) >= 1
+        for entry in loot:
+            assert "name_en" in entry
+            assert "name_cn" in entry
+
+    def test_player_endpoint_returns_bilingual_names(self, client):
+        """Player payload exposes season_name_en/cn and hero_name_en/cn."""
+        response = client.get("/api/player")
+        # The endpoint may 404 when no player is configured; only check shape
+        # when a player is actually returned.
+        if response.status_code == 200:
+            data = response.json()
+            assert "season_name_en" in data
+            assert "season_name_cn" in data
+            assert "hero_name_en" in data
+            assert "hero_name_cn" in data
+
+    def test_language_setting_round_trip(self, client):
+        """The `language` setting can be written and read back."""
+        # Default is empty / unset; PUT a value then GET it back.
+        put_resp = client.put(
+            "/api/settings/language",
+            json={"value": "zh-CN"},
+        )
+        assert put_resp.status_code in (200, 204)
+
+        get_resp = client.get("/api/settings/language")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["value"] == "zh-CN"
+
+        # Switch back to English.
+        client.put("/api/settings/language", json={"value": "en"})
+        assert client.get("/api/settings/language").json()["value"] == "en"
+

--- a/ti_tracker.spec
+++ b/ti_tracker.spec
@@ -59,6 +59,14 @@ hiddenimports = [
     'webview.platforms.edgechromium',
     'clr_loader',
     'pythonnet',
+    # Optional cloud sync (Supabase) — included so the in-app toggle works
+    # in the packaged build when the user enables Cloud Sync.
+    'supabase',
+    'gotrue',
+    'postgrest',
+    'realtime',
+    'storage3',
+    'supafunc',
 ]
 
 # Exclude unnecessary modules to reduce size


### PR DESCRIPTION
## Summary

Adds full English / Simplified Chinese language support across the web dashboard and the WPF overlay, with a language picker in Settings whose choice is persisted via the settings API. The overlay polls the language setting and re-applies labels live, so no restart is required when switching.

FE (Flame Elementium) is rendered as **源质** in the zh-CN copy throughout.

## Translation surfaces

- **Static UI strings** — new `src/titrack/web/static/i18n.js` holds the `TRANSLATIONS` table (~210 keys) and runtime helpers (`t(key)`, `applyTranslations`, `setLang`, `fetchZoneTranslations`). The DOM is walked for `[data-i18n]`, `[data-i18n-html]` (preserves inline `<strong>`, `<em>`, `<code>`), `[data-i18n-title]`, and `[data-i18n-placeholder]`. The Instructions and "Character Not Detected" modals — previously hard-coded English — are now fully translated.
- **Overlay UI strings** — new `overlay/Localization.cs` mirrors the web `TRANSLATIONS` table for the WPF overlay. `MainWindow` polls `/api/settings/language` every refresh tick (~2 s) and fires `LanguageChanged` so `ApplyLanguageLabels()` re-binds every label and tooltip in place.
- **Item names** — selection prefers `items.name_cn` when language is zh-CN and non-empty, falling back to `name_en`, then the legacy `name` column, then `Unknown ({id})`.
- **Zone names** — `src/titrack/data/zones.py` gains a `ZONE_NAMES_CN` dict alongside `ZONE_NAMES`, plus `get_zone_display_name_cn()`. The runtime `(Nightmare)` suffix is preserved/translated separately so any zone can be displayed in Nightmare mode without duplicating entries.
- **Season / hero names** — `src/titrack/parser/player_parser.py` gets `SEASON_NAMES_CN` and `HERO_NAMES_CN` so the header shows the Chinese season label.

## Zone translation accuracy

The five top-level region names match the in-game Chinese client (extracted from beacon item names in `tlidb_items_seed_en.json`):

| English | Chinese |
| --- | --- |
| Blistering Lava Sea | 沸涌炎海 |
| Glacial Abyss | 冰封寒渊 |
| Steel Forge | 钢铁炼境 |
| Thunder Wastes | 雷鸣废土 |
| Voidlands | 幽夜暗域 |

50+ sub-zone names were verified directly against in-game screenshots. A few highlights:

| English | Chinese |
| --- | --- |
| Shadow Outpost | 暗影前哨 |
| Demiman Village | 亚人村落 |
| Smelting Plant | 熔铁工厂 |
| City of Eternal Fire | 长明宫城 |
| Wall of the Pure | 无垢之墙 |
| Hall in the Mirror | 镜中礼堂 |
| Defiled Oasis | 不洁绿洲 |
| Summit of Thunder | 灾厄之林 |
| Filthy Forest | 污浊丛林 |
| Luminescent Throne | 流光神座 |

Special / boss zones verified against tlidb.com's autocomplete data:

| English | Chinese |
| --- | --- |
| Supreme Showdown | 巅峰对决 |
| Fateful Contest | 宿命对局 |
| Trial of Divinity | 神威试炼 |
| Void Sea Terminal | 虚空终港 |
| Quicksand Treasure Stash (Sandlord) | 流沙中的琳琅宝库（沙王） |

## API

- **New endpoint** `GET /api/i18n/zones` returns the `ZONE_NAMES_CN` dict so both the web app and the overlay can translate zone display names client-side without bundling the full table into each surface separately.
- `/api/settings/language` is now whitelisted in `ALLOWED_SETTINGS` so the language picker can round-trip through the standard settings API.

## Other fixes bundled in this branch

- **Cloud Sync toggle no longer stays disabled on first launch when no game log has been detected yet.** `SyncManager` is now created unconditionally in both browser and native-window serve paths (`src/titrack/cli/commands.py`), and the season context is set as soon as a `player_info` is available.
- **PyInstaller spec** (`ti_tracker.spec`) gains explicit `hiddenimports` for the supabase dependency chain (`supabase`, `gotrue`, `postgrest`, `realtime`, `storage3`, `supafunc`) so cloud sync works in the packaged EXE without silently falling back to `cloud_available: false`.

## Tests

- `tests/unit/test_api.py` adds coverage for the new `/api/i18n/zones` endpoint and the language settings round-trip.
- All existing tests continue to pass.

## Backwards compatibility

- Default language is `en`; existing users see no change unless they pick zh-CN in Settings.
- The new translation files are additive; nothing existing was removed.
- `data-i18n-html` is a new attribute used purely by the new translator; pages without it behave exactly as before.
